### PR TITLE
Add Servicelicense module

### DIFF
--- a/data/author.ts
+++ b/data/author.ts
@@ -55,6 +55,12 @@ export const authorData: Author[] = [
     id: "devife",
     URL: "https://devife.com",
   },
+    {
+    type: "organization",
+    name: "bojandenic",
+    id: "bojandenic",
+    URL: "https://www.kha-concepts.com",
+  },
 ];
 
 export function findAuthorByID(id: string): Author | undefined {

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -128,6 +128,52 @@ This product includes the following third party work:
     
  - Open Source Iconography by [Pictogrammers](https://pictogrammers.com/) licensed under the [Pictogrammers Free License](https://pictogrammers.com/docs/general/license/).`,
   },
+  {
+  id: "Servicelicense",
+  type: "mod",
+  name: "Servicelicense",
+  description:
+    "WordPress plugin license generation and secure ZIP distribution module for FOSSBilling.",
+  version: "v1.0.0",
+  download_url:
+    "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/v1.0.0/Servicelicense_release_v1.0.0.zip",
+  releases: [
+    {
+      tag: "v1.0.0",
+      date: "2026-02-15T17:42:00Z",
+      download_url:
+        "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/v1.0.0/Servicelicense_release_v1.0.0.zip",
+      changelog_url:
+        "https://github.com/bojandenic/fossbilling-servicelicense/releases/tag/v1.0.0",
+      min_fossbilling_version: "0.5",
+    },
+  ],
+  author: findAuthorByID("bojandenic"),
+  license: {
+    name: "MIT",
+    URL: "https://github.com/bojandenic/fossbilling-servicelicense/blob/main/LICENSE",
+  },
+  source: {
+    type: "github",
+    repo: "bojandenic/fossbilling-servicelicense",
+  },
+  icon_url:
+    "https://raw.githubusercontent.com/bojandenic/fossbilling-servicelicense/main/icon.svg",
+  website: "https://github.com/bojandenic/fossbilling-servicelicense",
+  readme: `Servicelicense is a FOSSBilling module for WordPress plugin vendors.
+
+Features:
+- License key generation per order
+- Secure ZIP download
+- Product-based configuration
+- Plugin version + changelog display
+- Optional domain validation
+
+Installation:
+1. Create /modules/Servicelicense/
+2. Extract ZIP inside that folder
+3. Enable in Admin → Extensions.`,
+},
   /*{
     id: "Serviceproxmox",
     type: "mod",

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -158,7 +158,7 @@ This product includes the following third party work:
     repo: "bojandenic/fossbilling-servicelicense",
   },
   icon_url:
-    "https://raw.githubusercontent.com/bojandenic/fossbilling-servicelicense/main/icon.svg",
+    "https://raw.githubusercontent.com/FOSSBilling/example-module/main/src/icon.svg",
   website: "https://github.com/bojandenic/fossbilling-servicelicense",
   readme: `Servicelicense is a FOSSBilling module for WordPress plugin vendors.
 

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -136,13 +136,13 @@ This product includes the following third party work:
     "WordPress plugin license generation and secure ZIP distribution module for FOSSBilling.",
   version: "1.0.0",
   download_url:
-    "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/fossbilling/Servicelicense_release_v1.0.0.zip",
+    "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/1.0.0/Servicelicense_release_v1.0.0.zip",
   releases: [
     {
       tag: "1.0.0",
       date: "2026-02-15T17:42:00Z",
       download_url:
-        "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/fossbilling/Servicelicense_release_v1.0.0.zip",
+        "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/1.0.0/Servicelicense_release_v1.0.0.zip",
       changelog_url:
         "https://github.com/bojandenic/fossbilling-servicelicense/releases/tag/fossbilling",
       min_fossbilling_version: "0.5",

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -140,11 +140,11 @@ This product includes the following third party work:
   releases: [
     {
       tag: "1.0.0",
-      date: "2026-02-15T17:42:00Z",
+      date: "2026-02-15T18:07:34Z",
       download_url:
         "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/1.0.0/Servicelicense_release_v1.0.0.zip",
       changelog_url:
-        "https://github.com/bojandenic/fossbilling-servicelicense/releases/tag/fossbilling",
+        "https://github.com/bojandenic/fossbilling-servicelicense/releases/tag/1.0.0",
       min_fossbilling_version: "0.5",
     },
   ],
@@ -158,8 +158,8 @@ This product includes the following third party work:
     repo: "bojandenic/fossbilling-servicelicense",
   },
   icon_url:
-    "https://raw.githubusercontent.com/FOSSBilling/example-module/main/src/icon.svg",
-  website: "https://github.com/bojandenic/fossbilling-servicelicense",
+    "https://raw.githubusercontent.com/bojandenic/fossbilling-servicelicense/refs/heads/main/licences-icon.svg",
+  website: "https://www.kha-concepts.com",
   readme: `Servicelicense is a FOSSBilling module for WordPress plugin vendors.
 
 Features:

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -134,12 +134,12 @@ This product includes the following third party work:
   name: "Servicelicense",
   description:
     "WordPress plugin license generation and secure ZIP distribution module for FOSSBilling.",
-  version: "v1.0.0",
+  version: "1.0.0",
   download_url:
     "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/fossbilling/Servicelicense_release_v1.0.0.zip",
   releases: [
     {
-      tag: "v1.0.0",
+      tag: "1.0.0",
       date: "2026-02-15T17:42:00Z",
       download_url:
         "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/fossbilling/Servicelicense_release_v1.0.0.zip",

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -136,15 +136,15 @@ This product includes the following third party work:
     "WordPress plugin license generation and secure ZIP distribution module for FOSSBilling.",
   version: "v1.0.0",
   download_url:
-    "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/v1.0.0/Servicelicense_release_v1.0.0.zip",
+    "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/fossbilling/Servicelicense_release_v1.0.0.zip",
   releases: [
     {
       tag: "v1.0.0",
       date: "2026-02-15T17:42:00Z",
       download_url:
-        "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/v1.0.0/Servicelicense_release_v1.0.0.zip",
+        "https://github.com/bojandenic/fossbilling-servicelicense/releases/download/fossbilling/Servicelicense_release_v1.0.0.zip",
       changelog_url:
-        "https://github.com/bojandenic/fossbilling-servicelicense/releases/tag/v1.0.0",
+        "https://github.com/bojandenic/fossbilling-servicelicense/releases/tag/fossbilling",
       min_fossbilling_version: "0.5",
     },
   ],


### PR DESCRIPTION
This PR adds the Servicelicense module to the extension directory.

Servicelicense is a WordPress plugin licensing and distribution module for FOSSBilling.

Features:
- License key generation per order
- Secure ZIP download (session-based)
- Product-based configuration
- Version and changelog display
- Optional domain validation

Repository:
https://github.com/bojandenic/fossbilling-servicelicense

Release:
v1.0.0

License:
MIT
