### PR TITLE
Add Yoco payment gateway listing

### DIFF
--- a/data/author.ts
+++ b/data/author.ts
@@ -55,6 +55,12 @@ export const authorData: Author[] = [
     id: "devife",
     URL: "https://devife.com",
   },
+  {
+    type: "user",
+    name: "demassimo",
+    id: "demassimo",
+    URL: "https://github.com/demassimo",
+  },
 ];
 
 export function findAuthorByID(id: string): Author | undefined {

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -1060,13 +1060,13 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
   },
   version: "0.5.1",
   download_url:
-    "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/archive/refs/tags/v0.5.1.zip",
+    "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/releases/download/v0.5.1/Yoco.zip",
   releases: [
     {
       tag: "0.5.1",
       date: "2026-05-10T09:22:26+02:00",
       download_url:
-        "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/archive/refs/tags/v0.5.1.zip",
+        "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/releases/download/v0.5.1/Yoco.zip",
       changelog_url:
         "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/releases/tag/v0.5.1",
       min_fossbilling_version: "0.7",

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -1043,5 +1043,78 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 1. OpenProvider for their robust API.
 1. FOSSBilling for their open-source billing platform.`,
+},
+{
+  id: "Yoco",
+  type: "payment-gateway",
+  name: "Yoco",
+  description: "Yoco payment gateway integration for FOSSBilling",
+  author: findAuthorByID("demassimo"),
+  license: {
+    name: "Apache 2.0",
+    URL: "https://www.apache.org/licenses/LICENSE-2.0",
+  },
+  source: {
+    type: "github",
+    repo: "demassimo/Yoco_Payment_Gateway_Fossbilling",
+  },
+  version: "0.5.1",
+  download_url:
+    "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/archive/refs/tags/v0.5.1.zip",
+  releases: [
+    {
+      tag: "0.5.1",
+      date: "2026-05-10T09:22:26+02:00",
+      download_url:
+        "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/archive/refs/tags/v0.5.1.zip",
+      changelog_url:
+        "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling/releases/tag/v0.5.1",
+      min_fossbilling_version: "0.6",
+    },
+  ],
+  icon_url:
+    "https://raw.githubusercontent.com/demassimo/Yoco_Payment_Gateway_Fossbilling/main/assets/yoco-icon.svg",
+  website: "https://github.com/demassimo/Yoco_Payment_Gateway_Fossbilling",
+  readme: `# FOSSBilling Yoco Gateway
+
+Yoco payment gateway integration for FOSSBilling.
+
+This extension lets FOSSBilling accept one-time Yoco Checkout payments in South African Rand (ZAR). It also supports optional USD invoice conversion into ZAR before checkout.
+
+## Features
+
+- One-time Yoco Checkout payments
+- ZAR invoice support
+- Optional USD-to-ZAR invoice conversion
+- Yoco webhook verification for payment confirmation
+- Test and live API key fields
+
+## Installation
+
+1. Download the latest release ZIP.
+2. Extract the archive into your FOSSBilling root so the paths merge into:
+   - \`library/Payment/Adapter/Yoco.php\`
+   - \`data/assets/gateways/yoco.png\`
+3. Clear the FOSSBilling cache.
+4. In the FOSSBilling admin panel, go to **System > Payment gateways**.
+5. Install or enable the **Yoco** payment gateway.
+6. Add your Yoco live or test keys.
+7. Configure your Yoco webhook and add the webhook secret in the gateway settings.
+
+## Currency notes
+
+Yoco checkout is processed in ZAR. ZAR invoices are charged directly. USD invoices can be converted to ZAR using the configured gateway conversion rate or the FOSSBilling currency rates.
+
+## Webhook notes
+
+The gateway verifies Yoco webhook signatures when a webhook secret is configured. Payment confirmation is handled through the \`payment.succeeded\` event.
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE).
+
+## Disclaimer
+
+This extension is not affiliated with FOSSBilling or Yoco.`,
 }
 ];


### PR DESCRIPTION
## Summary
- add `demassimo` as the Yoco extension author
- add the Yoco payment gateway entry to the extension directory
- point the listing at the refreshed `v0.5.1` source tag and updated icon asset

## Notes
- the Yoco repository now includes refreshed branding assets and the `v0.5.1` tag referenced by this listing
- no extension-directory UI or runtime code was changed
