### PR TITLE
Update name type in Organization and User

### DIFF
--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -28,14 +28,14 @@ export type Author = Organization | User;
 
 export type Organization = {
   type: 'organization';
-  name: Lowercase<string>;
+  name: string;
   id: Lowercase<string>;
   URL?: string;
 };
 
 export type User = {
   type: 'user';
-  name: Lowercase<string>;
+  name: string;
   id: Lowercase<string>;
   URL?: string;
 };


### PR DESCRIPTION
Changed the type of 'name' in Organization and User from Lowercase<string> to string.