### PR TITLE
Add ISPmanager 6 server manager for FOSSBilling

### DIFF
--- a/data/author.ts
+++ b/data/author.ts
@@ -67,6 +67,12 @@ export const authorData: Author[] = [
     id: "coinpayportal",
     URL: "https://coinpayportal.com",
   },
+  {
+    type: "organization",
+    name: "ServMe IT Limited",
+    id: "servmeit",
+    URL: "https://www.servmeit.co.nz",
+  },
 ];
 
 export function findAuthorByID(id: string): Author | undefined {

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -1214,7 +1214,7 @@ Apache 2.0`,
       },
     ],
     icon_url:
-      "https://www.ispmanager.com/wp-content/themes/ispmanager/assets/img/logo.svg",
+        "https://raw.githubusercontent.com/grant436/fossbilling-ispmanager/main/logo-ispmgr.svg",
     website: "https://github.com/grant436/fossbilling-ispmanager",
     readme: `# ISPmanager 6 Server Manager for FOSSBilling
 

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -1110,4 +1110,79 @@ For full configuration and webhook setup instructions, see the [documentation](h
 
 This extension is licensed under the MIT License. See the [LICENSE](https://github.com/profullstack/coinpayportal/blob/master/plugins/fossbilling/LICENSE) file for details.`,
 },
+{
+    id: "TPPWholesale",
+    type: "domain-registrar",
+    name: "TPP Wholesale",
+    description: "TPP Wholesale domain registrar adapter for FOSSBilling. Supports .co.nz, .nz, .com.au, .au and .com domains. Designed for New Zealand and Australian hosting businesses.",
+    author: getAuthor("servmeit"),
+    license: {
+      name: "Apache 2.0",
+      URL: "https://www.apache.org/licenses/LICENSE-2.0",
+    },
+    source: {
+      type: "github",
+      repo: "grant436/fossbilling-tpp-wholesale",
+    },
+    version: "1.0.0",
+    download_url:
+      "https://github.com/grant436/fossbilling-tpp-wholesale/archive/refs/tags/v1.0.0.zip",
+    releases: [
+      {
+        tag: "1.0.0",
+        date: "2026-06-07T00:00:00Z",
+        download_url:
+          "https://github.com/grant436/fossbilling-tpp-wholesale/archive/refs/tags/v1.0.0.zip",
+        changelog_url:
+          "https://github.com/grant436/fossbilling-tpp-wholesale/releases/tag/v1.0.0",
+        min_fossbilling_version: "0.8.2",
+      },
+    ],
+    icon_url:
+      "https://www.tppwholesale.com.au/wp-content/uploads/2022/12/TPP-logo-basic.png",
+    website: "https://github.com/grant436/fossbilling-tpp-wholesale",
+    readme: `# TPP Wholesale Registrar for FOSSBilling
+
+A domain registrar adapter for [FOSSBilling](https://fossbilling.org) that integrates with [TPP Wholesale](https://www.tppwholesale.com.au), the leading ANZ domain registrar.
+
+## Features
+
+- Domain availability checking
+- Domain registration (.co.nz, .nz, .com.au, .au, .com and more)
+- Domain renewal
+- Domain transfers
+- Nameserver management
+- Contact management
+- Domain locking/unlocking
+- EPP/auth code retrieval
+- Test mode for safe testing without registering real domains
+- Auto-derives TPP console account reference from API credentials
+
+## Requirements
+
+- FOSSBilling 0.8.2 or later (PHP 8.3+)
+- TPP Wholesale reseller account with API access enabled
+- TPP Legacy API credentials (Account No, Login, Password)
+
+## Installation
+
+1. Download \`TPPWholesale.php\` from the release archive
+2. Copy it to \`/library/Registrar/Adapter/TPPWholesale.php\` in your FOSSBilling installation
+3. In FOSSBilling admin go to **Domain Management → Registrars**
+4. Click **New Domain Registrar** and select **TPPWholesale**
+5. Click the cog icon and enter your TPP API credentials
+
+## Configuration
+
+| Field | Description | Required |
+|---|---|---|
+| Account Number | Your TPP account number | Yes |
+| User ID | Your TPP API login (e.g. SER-993-API) | Yes |
+| Password | Your TPP API password | Yes |
+| Console Account Reference | Your TPP account reference (e.g. SER-993). Leave blank to auto-derive from User ID | No |
+
+## License
+
+Apache 2.0`,
+},
 ];

--- a/data/extensions.ts
+++ b/data/extensions.ts
@@ -1185,4 +1185,68 @@ A domain registrar adapter for [FOSSBilling](https://fossbilling.org) that integ
 
 Apache 2.0`,
 },
+{
+    id: "ISPmanager",
+    type: "server-manager",
+    name: "ISPmanager 6",
+    description: "ISPmanager 6 server manager adapter for FOSSBilling. Automatically provisions hosting accounts, websites and SSL certificates when customers purchase hosting plans.",
+    author: getAuthor("servmeit"),
+    license: {
+      name: "Apache 2.0",
+      URL: "https://www.apache.org/licenses/LICENSE-2.0",
+    },
+    source: {
+      type: "github",
+      repo: "grant436/fossbilling-ispmanager",
+    },
+    version: "1.0.0",
+    download_url:
+      "https://github.com/grant436/fossbilling-ispmanager/archive/refs/tags/v1.0.0.zip",
+    releases: [
+      {
+        tag: "1.0.0",
+        date: "2026-06-10T00:00:00Z",
+        download_url:
+          "https://github.com/grant436/fossbilling-ispmanager/archive/refs/tags/v1.0.0.zip",
+        changelog_url:
+          "https://github.com/grant436/fossbilling-ispmanager/releases/tag/v1.0.0",
+        min_fossbilling_version: "0.8.2",
+      },
+    ],
+    icon_url:
+      "https://www.ispmanager.com/wp-content/themes/ispmanager/assets/img/logo.svg",
+    website: "https://github.com/grant436/fossbilling-ispmanager",
+    readme: `# ISPmanager 6 Server Manager for FOSSBilling
+
+Automatically provisions hosting accounts in [ISPmanager 6](https://www.ispmanager.com) when customers purchase hosting plans through [FOSSBilling](https://fossbilling.org).
+
+## Features
+
+- Automatic hosting account creation on purchase
+- Account suspension and unsuspension
+- Account cancellation and deletion
+- Password changes
+- Package upgrades and downgrades
+- Primary domain creation with PHP and SSL
+- Comprehensive API call logging
+
+## Requirements
+
+- FOSSBilling 0.8.2 or later (PHP 8.3+)
+- ISPmanager 6 (Lite, Pro or Host)
+- A dedicated API administrator user in ISPmanager (no 2FA)
+
+## Installation
+
+1. Download \`ispmanager.php\` from the release archive
+2. Copy it to \`/library/Server/Manager/ISPmanager.php\` in your FOSSBilling installation
+3. Create a dedicated API user in ISPmanager with administrator privileges and no 2FA
+4. Allow FOSSBilling to reach ISPmanager on port 1500
+5. In FOSSBilling go to **Products & Services → Hosting Plans → Servers** and add your server
+6. Set Server Manager to **ISPmanager**, enter credentials and click **Test Connection**
+
+## License
+
+Apache 2.0`,
+},
 ];


### PR DESCRIPTION
Adds ISPmanager 6 as a server manager adapter for FOSSBilling.

ISPmanager 6 is a popular hosting control panel. This module automatically provisions hosting accounts, websites and SSL certificates when customers purchase hosting plans through FOSSBilling.

Features:
- Automatic hosting account creation on purchase
- Account suspension, unsuspension and cancellation
- Password and package changes
- Primary domain creation with PHP and SSL
- Comprehensive API call logging

Repository: https://github.com/grant436/fossbilling-ispmanager