### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/components/ReleasesCard/index.tsx
+++ b/components/ReleasesCard/index.tsx
@@ -5,7 +5,6 @@ import { Extension, getLatestRelease, sortReleasesDescending } from "interfaces"
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 type Props = {
     ext?: Extension,


### PR DESCRIPTION
The best fix is to remove the unused `cn` import from `components/ReleasesCard/index.tsx` and leave all runtime behavior unchanged.

- **General approach:** delete imports that are not referenced in the file.
- **Specific change:** in `components/ReleasesCard/index.tsx`, remove:
  ```ts
  import { cn } from "@/lib/utils";
  ```
- **Why this is best:** it resolves the CodeQL warning with zero functional impact and keeps imports clean.
- **No additional methods/definitions/imports** are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._