### PR TITLE
Standardise account UI text capitalization

### DIFF
--- a/src/components/ExtensionSubmissionForm.astro
+++ b/src/components/ExtensionSubmissionForm.astro
@@ -25,7 +25,7 @@ const isEdit = Boolean(extension);
     <legend class="font-semibold mb-2">Publisher</legend>
     <p class="text-sm text-muted-foreground">
       Publishing as <strong>{developer.name}</strong> ({developer.id}).
-      <a href="/account/developer">Edit developer profile</a>
+      <a href="/account/developer">Edit Developer Profile</a>
     </p>
   </fieldset>
 
@@ -75,7 +75,7 @@ const isEdit = Boolean(extension);
       />
     </div>
     <div class="field">
-      <label for="description">Short description</label>
+      <label for="description">Short Description</label>
       <input
         class="input"
         type="text"
@@ -97,7 +97,7 @@ const isEdit = Boolean(extension);
       />
     </div>
     <div class="field">
-      <label for="icon_url">Icon URL (optional)</label>
+      <label for="icon_url">Icon URL (Optional)</label>
       <input
         class="input"
         type="url"
@@ -122,7 +122,7 @@ const isEdit = Boolean(extension);
   <fieldset class="fieldset space-y-4">
     <legend class="font-semibold mb-2">License</legend>
     <div class="field">
-      <label for="license_name">License name</label>
+      <label for="license_name">License Name</label>
       <input
         class="input"
         type="text"
@@ -133,7 +133,7 @@ const isEdit = Boolean(extension);
       />
     </div>
     <div class="field">
-      <label for="license_url">License URL (optional)</label>
+      <label for="license_url">License URL (Optional)</label>
       <input
         class="input"
         type="url"
@@ -147,7 +147,7 @@ const isEdit = Boolean(extension);
   <fieldset class="fieldset space-y-4">
     <legend class="font-semibold mb-2">Source</legend>
     <div class="field">
-      <label for="source_type">Repository host</label>
+      <label for="source_type">Repository Host</label>
       <select class="select" id="source_type" name="source_type">
         {
           SOURCE_TYPES.map((t) => (
@@ -175,7 +175,7 @@ const isEdit = Boolean(extension);
   {
     isEdit && extension && extension.releases.length > 0 && (
       <fieldset class="fieldset space-y-2">
-        <legend class="font-semibold mb-2">Existing releases</legend>
+        <legend class="font-semibold mb-2">Existing Releases</legend>
         <ul class="text-sm text-muted-foreground space-y-1">
           {extension.releases.map((r) => (
             <li>
@@ -193,7 +193,7 @@ const isEdit = Boolean(extension);
       {isEdit ? 'Add a new release (optional)' : 'Initial release'}
     </legend>
     <div class="field">
-      <label for="version_tag">Version tag</label>
+      <label for="version_tag">Version Tag</label>
       <input
         class="input"
         type="text"
@@ -204,7 +204,7 @@ const isEdit = Boolean(extension);
       />
     </div>
     <div class="field">
-      <label for="release_date">Release date</label>
+      <label for="release_date">Release Date</label>
       <input
         class="input"
         type="date"
@@ -224,11 +224,11 @@ const isEdit = Boolean(extension);
       />
     </div>
     <div class="field">
-      <label for="changelog_url">Changelog URL (optional)</label>
+      <label for="changelog_url">Changelog URL (Optional)</label>
       <input class="input" type="url" id="changelog_url" name="changelog_url" />
     </div>
     <div class="field">
-      <label for="min_fossbilling_version">Minimum FOSSBilling version</label>
+      <label for="min_fossbilling_version">Minimum FOSSBilling Version</label>
       <input
         class="input"
         type="text"
@@ -243,7 +243,7 @@ const isEdit = Boolean(extension);
   <div class="flex justify-end gap-3">
     <a href="/account" class="btn" data-variant="ghost"> Cancel </a>
     <button type="submit" class="btn">
-      {isEdit ? 'Submit edit for review' : 'Submit for review'}
+      {isEdit ? 'Submit Edit for Review' : 'Submit for Review'}
     </button>
   </div>
 </form>

--- a/src/pages/account/delete.astro
+++ b/src/pages/account/delete.astro
@@ -41,10 +41,10 @@ if (Astro.request.method === 'POST' && extensions.length === 0) {
 }
 ---
 
-<Base title="Delete account — FOSSBilling Extensions">
+<Base title="Delete Account — FOSSBilling Extensions">
   <div class="max-w-2xl mx-auto space-y-6">
     <h1 class="text-2xl font-semibold tracking-tight text-destructive">
-      Delete account
+      Delete Account
     </h1>
 
     {
@@ -85,7 +85,7 @@ if (Astro.request.method === 'POST' && extensions.length === 0) {
             </a>
             <form method="POST">
               <button type="submit" class="btn" data-variant="destructive">
-                Permanently delete my account
+                Permanently Delete My Account
               </button>
             </form>
           </div>

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -96,9 +96,9 @@ if (!isEdit) {
 }
 ---
 
-<Base title="Developer profile — FOSSBilling Extensions">
+<Base title="Developer Profile — FOSSBilling Extensions">
   <div class="max-w-2xl mx-auto space-y-6">
-    <h1 class="text-2xl font-semibold tracking-tight">Developer profile</h1>
+    <h1 class="text-2xl font-semibold tracking-tight">Developer Profile</h1>
     <p class="text-muted-foreground text-sm">
       This is the publisher identity shown on your extensions in the directory,
       and on your public developer page. Changes take effect immediately — you
@@ -109,13 +109,13 @@ if (!isEdit) {
     {
       !isEdit && myClaims.length > 0 && (
         <div class="card space-y-2">
-          <h2 class="font-semibold">Your profile claims</h2>
+          <h2 class="font-semibold">Your Profile Claims</h2>
           <ul class="space-y-2">
             {myClaims.map((c) => (
               <li class="text-sm flex items-center justify-between gap-3">
                 <code>{c.developer_id}</code>
                 {c.status === 'pending' && (
-                  <span class="badge-secondary">Pending review</span>
+                  <span class="badge-secondary">Pending Review</span>
                 )}
                 {c.status === 'approved' && <span class="badge">Approved</span>}
                 {c.status === 'rejected' && (
@@ -146,7 +146,7 @@ if (!isEdit) {
               {developer!.approved ? (
                 <span class="badge">Approved</span>
               ) : (
-                <span class="badge-secondary">Not yet reviewed</span>
+                <span class="badge-secondary">Not Yet Reviewed</span>
               )}
             </p>
             {developer!.bio && (
@@ -159,7 +159,7 @@ if (!isEdit) {
             data-size="sm"
             data-variant="outline"
           >
-            View public profile
+            View Public Profile
           </a>
         </div>
       )
@@ -175,7 +175,7 @@ if (!isEdit) {
 
     <form method="POST" class="space-y-8">
       <fieldset class="fieldset space-y-4">
-        <legend class="font-semibold mb-2">Publisher identity</legend>
+        <legend class="font-semibold mb-2">Publisher Identity</legend>
         <div class="field">
           <label for="id">Publisher ID</label>
           <input
@@ -198,7 +198,7 @@ if (!isEdit) {
           }
         </div>
         <div class="field">
-          <label for="name">Publisher name</label>
+          <label for="name">Publisher Name</label>
           <input
             class="input"
             type="text"
@@ -209,7 +209,7 @@ if (!isEdit) {
           />
         </div>
         <div class="field">
-          <label for="type">Publisher type</label>
+          <label for="type">Publisher Type</label>
           <select class="select" id="type" name="type">
             {
               DEVELOPER_TYPES.map((t) => (
@@ -221,7 +221,7 @@ if (!isEdit) {
           </select>
         </div>
         <div class="field">
-          <label for="url">Publisher URL (optional)</label>
+          <label for="url">Publisher URL (Optional)</label>
           <input
             class="input"
             type="url"
@@ -233,13 +233,13 @@ if (!isEdit) {
       </fieldset>
 
       <fieldset class="fieldset space-y-4">
-        <legend class="font-semibold mb-2">Public profile</legend>
+        <legend class="font-semibold mb-2">Public Profile</legend>
         <p class="text-sm text-muted-foreground -mt-2">
           Shown on your public developer page at
           {developer ? ` /developer/${developer.id}` : ' /developer/<your-id>'}.
         </p>
         <div class="field">
-          <label for="avatar_url">Avatar/logo URL (optional)</label>
+          <label for="avatar_url">Avatar/Logo URL (Optional)</label>
           <input
             class="input"
             type="url"
@@ -249,7 +249,7 @@ if (!isEdit) {
           />
         </div>
         <div class="field">
-          <label for="bio">Bio (optional)</label>
+          <label for="bio">Bio (Optional)</label>
           <textarea
             class="textarea"
             id="bio"
@@ -265,7 +265,7 @@ if (!isEdit) {
       <fieldset class="fieldset space-y-4">
         <legend class="font-semibold mb-2">Private contact</legend>
         <div class="field">
-          <label for="contact_email">Contact email (optional)</label>
+          <label for="contact_email">Contact Email (Optional)</label>
           <input
             class="input"
             type="email"
@@ -291,7 +291,7 @@ if (!isEdit) {
     {
       isEdit && (
         <div class="card space-y-3">
-          <h2 class="font-semibold">Transfer ownership</h2>
+          <h2 class="font-semibold">Transfer Ownership</h2>
           <p class="text-sm text-muted-foreground">
             Generate a one-time link to hand this profile to a different
             account. It works once and expires after 24 hours — generating a new
@@ -332,7 +332,7 @@ if (!isEdit) {
                 data-size="sm"
                 data-variant="outline"
               >
-                Generate transfer link
+                Generate Transfer Link
               </button>
             </form>
             <form method="POST" action="/account/developer/transfer/revoke">
@@ -342,7 +342,7 @@ if (!isEdit) {
                 data-size="sm"
                 data-variant="ghost"
               >
-                Revoke pending link
+                Revoke Pending Link
               </button>
             </form>
           </div>
@@ -354,7 +354,7 @@ if (!isEdit) {
       isEdit && (
         <div class="card space-y-3">
           <h2 class="font-semibold text-destructive">
-            Delete developer profile
+            Delete Developer Profile
           </h2>
           {extensions.length > 0 ? (
             <p class="text-sm text-muted-foreground">
@@ -377,7 +377,7 @@ if (!isEdit) {
                   data-size="sm"
                   data-variant="outline"
                 >
-                  Delete developer profile
+                  Delete Developer Profile
                 </button>
               </form>
             </>

--- a/src/pages/account/developer/transfer/[token].astro
+++ b/src/pages/account/developer/transfer/[token].astro
@@ -29,10 +29,10 @@ if (Astro.request.method === 'POST') {
 }
 ---
 
-<Base title="Accept developer profile transfer — FOSSBilling Extensions">
+<Base title="Accept Developer Profile Transfer — FOSSBilling Extensions">
   <div class="max-w-lg mx-auto space-y-6">
     <h1 class="text-2xl font-semibold tracking-tight">
-      Accept profile transfer
+      Accept Profile Transfer
     </h1>
     <p class="text-muted-foreground text-sm">
       Someone has sent you a link to take ownership of a developer profile.
@@ -49,7 +49,7 @@ if (Astro.request.method === 'POST') {
     }
 
     <form method="POST" class="flex gap-3">
-      <button type="submit" class="btn">Accept transfer</button>
+      <button type="submit" class="btn">Accept Transfer</button>
       <a href="/account" class="btn" data-variant="ghost">Cancel</a>
     </form>
   </div>

--- a/src/pages/account/extensions/new.astro
+++ b/src/pages/account/extensions/new.astro
@@ -37,9 +37,9 @@ if (Astro.request.method === 'POST') {
 }
 ---
 
-<Base title="Submit an extension — FOSSBilling Extensions">
+<Base title="Submit an Extension — FOSSBilling Extensions">
   <div class="max-w-2xl mx-auto space-y-6">
-    <h1 class="text-2xl font-semibold tracking-tight">Submit an extension</h1>
+    <h1 class="text-2xl font-semibold tracking-tight">Submit an Extension</h1>
     <p class="text-muted-foreground text-sm">
       Submissions are reviewed by a moderator before appearing in the public
       directory.

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -19,10 +19,10 @@ const [ownedExtensions, moderator, developer] = await Promise.all([
 ]);
 
 const banner: Record<string, string> = {
-  submitted: 'Submitted for review.',
-  profile_saved: 'Developer profile saved.',
-  profile_updated: 'Profile updated.',
-  profile_deleted: 'Developer profile deleted.',
+  submitted: 'Submitted for Review.',
+  profile_saved: 'Developer Profile Saved.',
+  profile_updated: 'Profile Updated.',
+  profile_deleted: 'Developer Profile Deleted.',
 };
 const bannerKey = [
   'submitted',
@@ -47,7 +47,7 @@ const statusBadgeClass: Record<Submission['status'], string> = {
 };
 ---
 
-<Base title="Your account — FOSSBilling Extensions">
+<Base title="Your Account — FOSSBilling Extensions">
   <div class="max-w-3xl mx-auto space-y-8">
     <header class="flex items-center justify-between gap-4">
       <div class="flex items-center gap-4">
@@ -63,12 +63,12 @@ const statusBadgeClass: Record<Submission['status'], string> = {
       </div>
       <div class="flex items-center gap-2">
         <a href="/account/profile" class="btn" data-variant="outline">
-          Your profile
+          Your Profile
         </a>
         {
           moderator && (
             <a href="/account/moderate" class="btn" data-variant="outline">
-              Moderation queue
+              Moderation Queue
             </a>
           )
         }
@@ -85,7 +85,7 @@ const statusBadgeClass: Record<Submission['status'], string> = {
 
     <section class="card">
       <header class="flex items-center justify-between">
-        <h2 class="font-semibold">Developer profile</h2>
+        <h2 class="font-semibold">Developer Profile</h2>
         <a
           href="/account/developer"
           class="btn"
@@ -103,7 +103,7 @@ const statusBadgeClass: Record<Submission['status'], string> = {
               {developer.approved ? (
                 <span class="badge">Approved</span>
               ) : (
-                <span class="badge-secondary">Not yet reviewed</span>
+                <span class="badge-secondary">Not Yet Reviewed</span>
               )}
             </p>
           ) : (
@@ -118,9 +118,9 @@ const statusBadgeClass: Record<Submission['status'], string> = {
 
     <section class="card">
       <header class="flex items-center justify-between">
-        <h2 class="font-semibold">Your extensions</h2>
+        <h2 class="font-semibold">Your Extensions</h2>
         <a href="/account/extensions/new" class="btn" data-size="sm">
-          Submit new extension
+          Submit New Extension
         </a>
       </header>
       <section>
@@ -170,7 +170,7 @@ const statusBadgeClass: Record<Submission['status'], string> = {
 
     <section class="card">
       <header>
-        <h2 class="font-semibold">Your submissions</h2>
+        <h2 class="font-semibold">Your Submissions</h2>
       </header>
       <section>
         {
@@ -207,7 +207,7 @@ const statusBadgeClass: Record<Submission['status'], string> = {
 
     <div class="text-center">
       <a href="/account/delete" class="text-sm text-destructive">
-        Delete account
+        Delete Account
       </a>
     </div>
   </div>

--- a/src/pages/account/moderate/developers/[id]/history.astro
+++ b/src/pages/account/moderate/developers/[id]/history.astro
@@ -28,14 +28,14 @@ try {
 }
 ---
 
-<Base title={`Profile history: ${id} — FOSSBilling Extensions`}>
+<Base title={`Profile History: ${id} — FOSSBilling Extensions`}>
   <div class="max-w-2xl mx-auto space-y-6">
     <div class="flex items-center justify-between gap-4">
       <h1 class="text-2xl font-semibold tracking-tight">
         History for <code>{id}</code>
       </h1>
       <a href="/account/moderate/developers" class="btn" data-variant="outline">
-        Back to profiles
+        Back to Profiles
       </a>
     </div>
 

--- a/src/pages/account/moderate/developers/claims/index.astro
+++ b/src/pages/account/moderate/developers/claims/index.astro
@@ -23,10 +23,10 @@ try {
   <div class="max-w-3xl mx-auto space-y-6">
     <div class="flex items-center justify-between gap-4">
       <h1 class="text-2xl font-semibold tracking-tight">
-        Profile claims awaiting review
+        Profile Claims Awaiting Review
       </h1>
       <a href="/account/moderate/developers" class="btn" data-variant="outline">
-        Developer profiles
+        Developer Profiles
       </a>
     </div>
 

--- a/src/pages/account/moderate/developers/index.astro
+++ b/src/pages/account/moderate/developers/index.astro
@@ -37,7 +37,7 @@ try {
           data-size="sm"
           data-variant="outline"
         >
-          Claims queue
+          Claims Queue
         </a>
         <a
           href="/account/moderate"
@@ -45,7 +45,7 @@ try {
           data-size="sm"
           data-variant="outline"
         >
-          Extension queue
+          Extension Queue
         </a>
       </div>
     </div>
@@ -59,7 +59,7 @@ try {
             data-size="sm"
             data-variant={v === view ? 'primary' : 'outline'}
           >
-            {v === 'unapproved' ? 'Awaiting review' : 'All profiles'}
+            {v === 'unapproved' ? 'Awaiting Review' : 'All Profiles'}
           </a>
         ))
       }

--- a/src/pages/account/moderate/index.astro
+++ b/src/pages/account/moderate/index.astro
@@ -25,12 +25,12 @@ try {
 }
 ---
 
-<Base title="Moderation queue — FOSSBilling Extensions">
+<Base title="Moderation Queue — FOSSBilling Extensions">
   <div class="max-w-3xl mx-auto space-y-6">
     <div class="flex items-center justify-between gap-4">
-      <h1 class="text-2xl font-semibold tracking-tight">Moderation queue</h1>
+      <h1 class="text-2xl font-semibold tracking-tight">Moderation Queue</h1>
       <a href="/account/moderate/developers" class="btn" data-variant="outline">
-        Developer profiles
+        Developer Profiles
       </a>
     </div>
 
@@ -83,7 +83,7 @@ try {
                 <p class="text-sm">{s.payload.extension.description}</p>
                 <details class="mt-2">
                   <summary class="text-sm text-muted-foreground cursor-pointer">
-                    Full payload
+                    Full Payload
                   </summary>
                   <pre class="text-xs mt-2 overflow-x-auto bg-muted rounded-md p-3">
                     {JSON.stringify(s.payload, null, 2)}

--- a/src/pages/account/profile/index.astro
+++ b/src/pages/account/profile/index.astro
@@ -24,9 +24,9 @@ if (Astro.request.method === 'POST') {
 const profile = await getUserProfile(env.DB_EXTENSIONS, user.sub);
 ---
 
-<Base title="Your profile — FOSSBilling Extensions">
+<Base title="Your Profile — FOSSBilling Extensions">
   <div class="max-w-2xl mx-auto space-y-6">
-    <h1 class="text-2xl font-semibold tracking-tight">Your profile</h1>
+    <h1 class="text-2xl font-semibold tracking-tight">Your Profile</h1>
     <p class="text-muted-foreground text-sm">
       Your personal profile, separate from any developer/publisher identity. Not
       shown publicly yet — it's here for things like comments and ratings down
@@ -35,7 +35,7 @@ const profile = await getUserProfile(env.DB_EXTENSIONS, user.sub);
 
     <form method="POST" class="space-y-6">
       <div class="field">
-        <label for="display_name">Display name</label>
+        <label for="display_name">Display Name</label>
         <input
           class="input"
           type="text"

--- a/src/pages/developer/[id].astro
+++ b/src/pages/developer/[id].astro
@@ -145,7 +145,7 @@ const extensions = await getExtensionsByDeveloperId(
                 data-size="sm"
                 data-variant="outline"
               >
-                Sign in to claim this profile
+                Sign In to Claim This Profile
               </a>
             )}
           </>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes capitalization to Title Case across account, developer, submission, and moderation UI for consistent copy and better readability. No functional changes.

- **Refactors**
  - Updated headings, legends, labels, buttons, badges, banners, and page titles to Title Case (e.g., "Delete Account", "Moderation Queue", "Existing Releases").
  - Applied updates in `src/components/ExtensionSubmissionForm.astro` and related account pages (delete, developer profile/transfer, extensions/new, account index, moderation views, user profile, and public developer page).

<sup>Written for commit 1110d5a6617291bc1a1c40770f1d24cd50da5da1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

