### PR TITLE
Remove bio fields from profile and developer UI

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -40,7 +40,7 @@ const SELECT_EXTENSIONS_BY_DEVELOPER = `
 // unclaimed is derived, never the raw owner_user_id — exposing the actual
 // owner's sub would leak another user's identifier publicly.
 const SELECT_DEVELOPER_PUBLIC = `
-  SELECT id, type, name, url, bio, avatar_url, approved_at,
+  SELECT id, type, name, url, avatar_url, approved_at,
          (owner_user_id IS NULL) AS unclaimed
   FROM developers
 `;
@@ -50,7 +50,6 @@ type DeveloperProfileRow = {
   type: string;
   name: string;
   url: string | null;
-  bio?: string | null;
   avatar_url: string | null;
   contact_email?: string | null;
   approved_at: string | null;
@@ -63,7 +62,6 @@ function parseDeveloperProfileRow(row: DeveloperProfileRow): DeveloperProfile {
     name: row.name,
     id: row.id.toLowerCase() as Lowercase<string>,
     URL: row.url ?? undefined,
-    bio: row.bio ?? undefined,
     avatar_url: row.avatar_url ?? undefined,
     contact_email: row.contact_email ?? undefined,
     approved: row.approved_at !== null,
@@ -140,7 +138,7 @@ export async function getDeveloperByOwner(
   try {
     row = await db
       .prepare(
-        'SELECT id, type, name, url, bio, avatar_url, contact_email, approved_at FROM developers WHERE owner_user_id = ?',
+        'SELECT id, type, name, url, avatar_url, contact_email, approved_at FROM developers WHERE owner_user_id = ?',
       )
       .bind(userId)
       .first<DeveloperProfileRow>();

--- a/src/lib/db/migrations/0004_drop_bio.sql
+++ b/src/lib/db/migrations/0004_drop_bio.sql
@@ -1,0 +1,4 @@
+-- Drops the personal-profile bio column added by 0003_add_profile_fields.sql
+-- — the feature was removed; display_name is kept.
+
+ALTER TABLE users DROP COLUMN bio;

--- a/src/lib/developer-form.ts
+++ b/src/lib/developer-form.ts
@@ -30,7 +30,6 @@ export function buildDeveloperProfile(
     type: isDeveloperType(typeInput) ? typeInput : 'user',
     name: str('name'),
     URL: str('url') || undefined,
-    bio: str('bio') || undefined,
     avatar_url: str('avatar_url') || undefined,
     contact_email: str('contact_email') || undefined,
   } as DeveloperProfileInput;

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -59,21 +59,20 @@ export async function deleteUser(
 
 export type UserProfile = {
   display_name: string | null;
-  bio: string | null;
 };
 
-// display_name/bio are a personal profile, separate from the name/email/
+// display_name is a personal profile, separate from the name/email/
 // picture synced from the auth provider on every login (upsertUser above
-// never touches them) and separate from any developer/publisher identity.
+// never touches it) and separate from any developer/publisher identity.
 export async function getUserProfile(
   db: D1Database,
   userId: string,
 ): Promise<UserProfile> {
   const row = await db
-    .prepare('SELECT display_name, bio FROM users WHERE id = ?')
+    .prepare('SELECT display_name FROM users WHERE id = ?')
     .bind(userId)
     .first<UserProfile>();
-  return row ?? { display_name: null, bio: null };
+  return row ?? { display_name: null };
 }
 
 // Callback.ts deliberately doesn't fail sign-in if upsertUser fails (a
@@ -96,9 +95,7 @@ export async function updateUserProfile(
     .run();
 
   await db
-    .prepare(
-      'UPDATE users SET display_name = ?, bio = ?, updated_at = ? WHERE id = ?',
-    )
-    .bind(profile.display_name, profile.bio, now, userId)
+    .prepare('UPDATE users SET display_name = ?, updated_at = ? WHERE id = ?')
+    .bind(profile.display_name, now, userId)
     .run();
 }

--- a/src/pages/account/delete.astro
+++ b/src/pages/account/delete.astro
@@ -71,7 +71,7 @@ if (Astro.request.method === 'POST' && extensions.length === 0) {
             {developer && ' and your developer profile'}. This can't be undone.
           </p>
           <ul class="text-sm text-muted-foreground list-disc pl-5 space-y-1">
-            <li>Your personal profile (display name, bio) is removed.</li>
+            <li>Your personal profile (display name) is removed.</li>
             {developer && (
               <li>
                 Your developer profile ({developer.name}) and its public page

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -350,9 +350,9 @@ if (!isEdit) {
           ) : (
             <>
               <p class="text-sm text-muted-foreground">
-                Permanently deletes your publisher identity (name, contact
-                info) and its public page. This can't be undone, and the ID may
-                be used by someone else afterward.
+                Permanently deletes your publisher identity (name, contact info)
+                and its public page. This can't be undone, and the ID may be
+                used by someone else afterward.
               </p>
               <form method="POST">
                 <input type="hidden" name="intent" value="delete" />

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -149,9 +149,6 @@ if (!isEdit) {
                 <span class="badge-secondary">Not Yet Reviewed</span>
               )}
             </p>
-            {developer!.bio && (
-              <p class="text-sm text-muted-foreground mt-1">{developer!.bio}</p>
-            )}
           </div>
           <a
             href={`/developer/${developer!.id}`}
@@ -248,18 +245,6 @@ if (!isEdit) {
             value={fields?.avatar_url}
           />
         </div>
-        <div class="field">
-          <label for="bio">Bio (Optional)</label>
-          <textarea
-            class="textarea"
-            id="bio"
-            name="bio"
-            rows="4"
-            maxlength="500"
-            set:text={fields?.bio ?? ''}
-          />
-          <p class="text-sm text-muted-foreground">Up to 500 characters.</p>
-        </div>
       </fieldset>
 
       <fieldset class="fieldset space-y-4">
@@ -283,7 +268,7 @@ if (!isEdit) {
       <div class="flex justify-end gap-3">
         <a href="/account" class="btn" data-variant="ghost">Cancel</a>
         <button type="submit" class="btn">
-          {isEdit ? 'Save changes' : 'Create developer profile'}
+          {isEdit ? 'Save Changes' : 'Create Developer Profile'}
         </button>
       </div>
     </form>
@@ -365,7 +350,7 @@ if (!isEdit) {
           ) : (
             <>
               <p class="text-sm text-muted-foreground">
-                Permanently deletes your publisher identity (name, bio, contact
+                Permanently deletes your publisher identity (name, contact
                 info) and its public page. This can't be undone, and the ID may
                 be used by someone else afterward.
               </p>

--- a/src/pages/account/profile/index.astro
+++ b/src/pages/account/profile/index.astro
@@ -12,11 +12,9 @@ const user = guard;
 if (Astro.request.method === 'POST') {
   const form = await Astro.request.formData();
   const displayName = formString(form, 'display_name');
-  const bio = formString(form, 'bio');
 
   await updateUserProfile(env.DB_EXTENSIONS, user.sub, {
     display_name: displayName || null,
-    bio: bio || null,
   });
   return Astro.redirect('/account?profile_updated=1');
 }
@@ -28,9 +26,7 @@ const profile = await getUserProfile(env.DB_EXTENSIONS, user.sub);
   <div class="max-w-2xl mx-auto space-y-6">
     <h1 class="text-2xl font-semibold tracking-tight">Your Profile</h1>
     <p class="text-muted-foreground text-sm">
-      Your personal profile, separate from any developer/publisher identity. Not
-      shown publicly yet — it's here for things like comments and ratings down
-      the line.
+      Your personal profile, separate from any developer/publisher identity.
     </p>
 
     <form method="POST" class="space-y-6">
@@ -47,16 +43,6 @@ const profile = await getUserProfile(env.DB_EXTENSIONS, user.sub);
         <p class="text-sm text-muted-foreground">
           Defaults to "{user.name}" from your sign-in provider if left blank.
         </p>
-      </div>
-      <div class="field">
-        <label for="bio">Bio</label>
-        <textarea
-          class="textarea"
-          id="bio"
-          name="bio"
-          rows="4"
-          set:text={profile.bio ?? ''}
-        />
       </div>
 
       <div class="flex justify-end gap-3">

--- a/src/pages/developer/[id].astro
+++ b/src/pages/developer/[id].astro
@@ -71,11 +71,6 @@ const extensions = await getExtensionsByDeveloperId(
         {developer.unclaimed && <span class="badge-secondary">Unclaimed</span>}
       </div>
       {
-        developer.bio && (
-          <p class="text-muted-foreground mt-2 max-w-2xl">{developer.bio}</p>
-        )
-      }
-      {
         developer.URL && isSafeHttpUrl(developer.URL) ? (
           <a
             href={developer.URL}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,12 +106,11 @@ export type SubmissionPayload = {
 // src/services/extensions/v2/interfaces.ts (DeveloperProfileSchema).
 // Developer profiles are written directly (PUT /extensions/v2/developers/me),
 // not through the submission/moderation queue; `approved` is purely a badge,
-// not a gate. bio/avatar_url are shown on the public /developer/[id] page;
+// not a gate. avatar_url is shown on the public /developer/[id] page;
 // contact_email is never read by any public-facing query — it's for
 // moderator/maintainer contact only, same trust level as a user's own email.
 export type DeveloperProfile = Developer & {
   approved: boolean;
-  bio?: string;
   avatar_url?: string;
   contact_email?: string;
   // Local-only: derived from `owner_user_id IS NULL` by getDeveloperById's


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed all bio fields from user and developer profiles. Cleaned up UI, types, and queries, and dropped `users.bio`; `display_name` remains.

- **Refactors**
  - Removed `bio` from developer schema, queries, parsing, and forms; deleted bio display in account and public developer pages.
  - Simplified personal profile to `display_name` only; updated copy (delete flow, button casing) and reflowed delete warning text on the developer page.

- **Migration**
  - Run `src/lib/db/migrations/0004_drop_bio.sql` to drop `users.bio`.
  - Remove any references to `DeveloperProfile['bio']` or form field `bio`.

<sup>Written for commit 24f98734aa48bf53681590bcc348f6867abbf0e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

