### PR TITLE
Sync developer-approval and transfer-accept calls with api's v2 hardening

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -103,9 +103,13 @@ export function createApiClient(env: Cloudflare.Env, sub: string) {
 
     listAllDevelopers: () => call<DeveloperProfile[]>('/developers'),
 
-    approveDeveloper: (id: string) =>
+    // expectedRevision must match the profile's current content_revision —
+    // the api rejects the approval with 409 if the profile changed since it
+    // was reviewed.
+    approveDeveloper: (id: string, expectedRevision: number) =>
       call<{ id: string; approved: true }>(`/developers/${id}/approve`, {
         method: 'POST',
+        body: JSON.stringify({ expected_revision: expectedRevision }),
       }),
 
     listDeveloperHistory: (id: string) =>
@@ -124,8 +128,9 @@ export function createApiClient(env: Cloudflare.Env, sub: string) {
       }),
 
     acceptTransfer: (token: string) =>
-      call<DeveloperProfile>(`/developers/transfers/${token}/accept`, {
+      call<DeveloperProfile>('/developers/transfers/accept', {
         method: 'POST',
+        body: JSON.stringify({ token }),
       }),
 
     claimDeveloper: (id: string, note?: string) =>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -54,6 +54,9 @@ type DeveloperProfileRow = {
   contact_email?: string | null;
   approved_at: string | null;
   unclaimed?: number;
+  // Not selected by SELECT_DEVELOPER_PUBLIC — getDeveloperById's return type
+  // omits content_revision, so the fallback below is never exposed there.
+  content_revision?: number;
 };
 
 function parseDeveloperProfileRow(row: DeveloperProfileRow): DeveloperProfile {
@@ -65,6 +68,7 @@ function parseDeveloperProfileRow(row: DeveloperProfileRow): DeveloperProfile {
     avatar_url: row.avatar_url ?? undefined,
     contact_email: row.contact_email ?? undefined,
     approved: row.approved_at !== null,
+    content_revision: row.content_revision ?? 1,
     unclaimed: row.unclaimed === 1,
   } as DeveloperProfile;
 }
@@ -138,7 +142,7 @@ export async function getDeveloperByOwner(
   try {
     row = await db
       .prepare(
-        'SELECT id, type, name, url, avatar_url, contact_email, approved_at FROM developers WHERE owner_user_id = ?',
+        'SELECT id, type, name, url, avatar_url, contact_email, approved_at, content_revision FROM developers WHERE owner_user_id = ?',
       )
       .bind(userId)
       .first<DeveloperProfileRow>();

--- a/src/pages/account/moderate/developers/[id]/approve.ts
+++ b/src/pages/account/moderate/developers/[id]/approve.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient, ApiRequestError } from '@/lib/apiClient';
+import { formString } from '@/lib/form';
 
 export const POST: APIRoute = async (context) => {
   const guard = await requireModerator(context, env);
@@ -11,9 +12,24 @@ export const POST: APIRoute = async (context) => {
   const { id } = context.params;
   if (!id) return context.redirect('/account/moderate/developers');
 
+  let form: FormData;
+  try {
+    form = await context.request.formData();
+  } catch {
+    return context.redirect(
+      `/account/moderate/developers?error=${encodeURIComponent('Malformed request.')}`,
+    );
+  }
+  const expectedRevision = Number(formString(form, 'expected_revision'));
+  if (!Number.isInteger(expectedRevision) || expectedRevision < 1) {
+    return context.redirect(
+      `/account/moderate/developers?error=${encodeURIComponent('Missing or invalid profile revision.')}`,
+    );
+  }
+
   const api = createApiClient(env, user.sub);
   try {
-    await api.approveDeveloper(id);
+    await api.approveDeveloper(id, expectedRevision);
   } catch (e) {
     const message =
       e instanceof ApiRequestError ? e.message : 'Unable to approve profile.';

--- a/src/pages/account/moderate/developers/index.astro
+++ b/src/pages/account/moderate/developers/index.astro
@@ -129,6 +129,11 @@ try {
                       method="POST"
                       action={`/account/moderate/developers/${d.id}/approve`}
                     >
+                      <input
+                        type="hidden"
+                        name="expected_revision"
+                        value={d.content_revision}
+                      />
                       <button type="submit" class="btn" data-size="sm">
                         Approve
                       </button>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -113,6 +113,10 @@ export type DeveloperProfile = Developer & {
   approved: boolean;
   avatar_url?: string;
   contact_email?: string;
+  // Bumped by the api repo on every profile write; required by
+  // POST /developers/{id}/approve as `expected_revision` so an approval
+  // can't silently apply to a profile edited after it was reviewed.
+  content_revision: number;
   // Local-only: derived from `owner_user_id IS NULL` by getDeveloperById's
   // own query, not part of the api repo's DeveloperProfile response. Never
   // set on profiles read via the api client (upsertDeveloperProfile,
@@ -122,16 +126,20 @@ export type DeveloperProfile = Developer & {
 };
 
 // Body for PUT /extensions/v2/developers/me — everything but the server-set
-// `approved` flag.
+// `approved` flag and `content_revision` (bumped by the api repo itself).
 export type DeveloperProfileInput = Omit<
   DeveloperProfile,
-  'approved' | 'unclaimed'
+  'approved' | 'unclaimed' | 'content_revision'
 >;
 
 // What getDeveloperById (the public /developer/[id] read) returns —
-// contact_email is owner/moderator-only, so it's excluded at the type level
-// rather than relying solely on the query not selecting it.
-export type PublicDeveloperProfile = Omit<DeveloperProfile, 'contact_email'>;
+// contact_email is owner/moderator-only and content_revision is an internal
+// moderation concern, so both are excluded at the type level rather than
+// relying solely on the query not selecting them.
+export type PublicDeveloperProfile = Omit<
+  DeveloperProfile,
+  'contact_email' | 'content_revision'
+>;
 
 // A snapshot of a developers row as it existed right after one
 // PUT /developers/me write — see the api repo's DeveloperHistoryEntrySchema.


### PR DESCRIPTION
## Summary
- The `fossbilling/api` repo's "Harden extensions v2 review workflows" change made `POST /developers/{id}/approve` require an `expected_revision` body (matching the profile's `content_revision`) as an optimistic-concurrency guard, and moved transfer acceptance from `POST /developers/transfers/{token}/accept` to `POST /developers/transfers/accept` with `token` in the JSON body — both were silent breaks for this site's API client.
- Updated `apiClient.ts` (`approveDeveloper`, `acceptTransfer`), added `content_revision` to the `DeveloperProfile` type (and excluded it from `DeveloperProfileInput`/`PublicDeveloperProfile`), and threaded `expected_revision` through the developer-approval form and route handler.
- Other recent api changes (`DELETE /developers/me`, new public read endpoints, submission-list pagination) were checked and need no changes here — the delete endpoint was already wired up, the public read endpoints aren't used since this site reads D1 directly, and pagination is additive.