### PR TITLE
Improve developer profile claim flow and add GitHub verification

### DIFF
--- a/src/lib/db/migrations/0005_add_github_fields.sql
+++ b/src/lib/db/migrations/0005_add_github_fields.sql
@@ -1,0 +1,9 @@
+-- Linked GitHub identity, synced from the auth service's custom OIDC claims
+-- on every login (see auth/callback.ts). github_orgs is a JSON-encoded array
+-- of lowercase org logins. Both null until a user completes a GitHub login
+-- after the auth service started requesting the read:org scope. Read by the
+-- api repo (same DB_EXTENSIONS binding) to verify developer profile claims —
+-- see the api repo's developers-database.ts claim().
+
+ALTER TABLE users ADD COLUMN github_login TEXT;
+ALTER TABLE users ADD COLUMN github_orgs TEXT;

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -90,6 +90,12 @@ export type UserInfo = {
   email?: string;
   email_verified?: boolean;
   picture?: string;
+  // Linked GitHub identity, present once a user has signed in via GitHub
+  // after the auth service started requesting the read:org scope — see
+  // upsertUser in users.ts. github_orgs is the caller's active org logins,
+  // used to verify developer profile claims (api repo's claim()).
+  'https://fossbilling.org/claims/github_login'?: string;
+  'https://fossbilling.org/claims/github_orgs'?: string[];
 };
 
 export async function fetchUserInfo(accessToken: string): Promise<UserInfo> {

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -5,15 +5,20 @@ export async function upsertUser(
   info: UserInfo,
 ): Promise<void> {
   const now = new Date().toISOString();
+  const githubLogin =
+    info['https://fossbilling.org/claims/github_login'] ?? null;
+  const githubOrgs = info['https://fossbilling.org/claims/github_orgs'];
   await db
     .prepare(
-      `INSERT INTO users (id, name, email, email_verified, picture, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO users (id, name, email, email_verified, picture, github_login, github_orgs, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          name = excluded.name,
          email = excluded.email,
          email_verified = excluded.email_verified,
          picture = excluded.picture,
+         github_login = excluded.github_login,
+         github_orgs = excluded.github_orgs,
          updated_at = excluded.updated_at`,
     )
     .bind(
@@ -22,6 +27,8 @@ export async function upsertUser(
       info.email ?? null,
       info.email_verified ? 1 : 0,
       info.picture ?? null,
+      githubLogin,
+      githubOrgs ? JSON.stringify(githubOrgs) : null,
       now,
       now,
     )

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -205,9 +205,15 @@ if (!isEdit) {
             readonly={isEdit}
           />
           {
-            isEdit && (
+            isEdit ? (
               <p class="text-sm text-muted-foreground">
                 The ID can't be changed after it's created.
+              </p>
+            ) : (
+              <p class="text-sm text-muted-foreground">
+                Typically your GitHub organization or username — this is used
+                to verify ownership if you (or someone else) later try to
+                claim this profile.
               </p>
             )
           }

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -32,6 +32,10 @@ const extensions = isEdit
 const api = createApiClient(env, user.sub);
 
 let error: string | null = Astro.url.searchParams.get('error');
+// Set only when creation failed because the id belongs to an existing,
+// unowned profile (e.g. a legacy extension author) — points the user at
+// the claim flow on that profile's public page instead of a dead end.
+let idTaken = false;
 let transferResult: DeveloperTransfer | null = null;
 // Falls back to the just-submitted values on a failed save, so a rejected
 // submission (e.g. duplicate id) doesn't blank the form and force retyping.
@@ -78,6 +82,10 @@ if (Astro.request.method === 'POST') {
         e instanceof ApiRequestError || e instanceof DeveloperValidationError
           ? e.message
           : 'Something went wrong saving your developer profile. Please try again.';
+      idTaken =
+        !isEdit &&
+        e instanceof ApiRequestError &&
+        e.message === 'Developer id already exists';
     }
   }
 }
@@ -165,7 +173,17 @@ if (!isEdit) {
     {
       error && (
         <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
+          <p>{error}</p>
+          {idTaken && submitted?.id && (
+            <p class="mt-2">
+              If this is your existing extension author profile, you can
+              request to claim it instead of creating a new one — visit{' '}
+              <a href={`/developer/${submitted.id}`} class="underline">
+                the public profile page for "{submitted.id}"
+              </a>{' '}
+              and use the "Claim this profile" option.
+            </p>
+          )}
         </div>
       )
     }

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -176,8 +176,8 @@ if (!isEdit) {
           <p>{error}</p>
           {idTaken && submitted?.id && (
             <p class="mt-2">
-              If this is your existing extension author profile, you can
-              request to claim it instead of creating a new one — visit{' '}
+              If this is your existing extension author profile, you can request
+              to claim it instead of creating a new one — visit{' '}
               <a href={`/developer/${submitted.id}`} class="underline">
                 the public profile page for "{submitted.id}"
               </a>{' '}
@@ -211,9 +211,9 @@ if (!isEdit) {
               </p>
             ) : (
               <p class="text-sm text-muted-foreground">
-                Typically your GitHub organization or username — this is used
-                to verify ownership if you (or someone else) later try to
-                claim this profile.
+                Typically your GitHub organization or username — this is used to
+                verify ownership if you (or someone else) later try to claim
+                this profile.
               </p>
             )
           }

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -3,7 +3,11 @@ import Base from '../../../layouts/Base.astro';
 import { env } from 'cloudflare:workers';
 import { requireUser } from '@/lib/auth-guard';
 import { createApiClient, ApiRequestError } from '@/lib/apiClient';
-import { getDeveloperByOwner, getExtensionsByOwner } from '@/lib/database';
+import {
+  getDeveloperByOwner,
+  getDeveloperById,
+  getExtensionsByOwner,
+} from '@/lib/database';
 import {
   buildDeveloperProfile,
   DeveloperValidationError,
@@ -82,10 +86,23 @@ if (Astro.request.method === 'POST') {
         e instanceof ApiRequestError || e instanceof DeveloperValidationError
           ? e.message
           : 'Something went wrong saving your developer profile. Please try again.';
-      idTaken =
+      // Matched on the api repo's dedicated DEVELOPER_ID_TAKEN code, not the
+      // message text, so a reworded message can't silently break this. Only
+      // points at the claim flow when the conflicting profile is actually
+      // unclaimed — a profile someone else already owns has no claim option,
+      // so showing this guidance there would be a dead end.
+      if (
         !isEdit &&
         e instanceof ApiRequestError &&
-        e.message === 'Developer id already exists';
+        e.code === 'DEVELOPER_ID_TAKEN' &&
+        submitted?.id
+      ) {
+        const conflicting = await getDeveloperById(
+          env.DB_EXTENSIONS,
+          submitted.id,
+        );
+        idTaken = conflicting?.unclaimed === true;
+      }
     }
   }
 }

--- a/src/pages/account/moderate/developers/claims/index.astro
+++ b/src/pages/account/moderate/developers/claims/index.astro
@@ -40,8 +40,10 @@ try {
 
     <p class="text-sm text-muted-foreground">
       These profiles have no linked account. Approving gives the claimant
-      ownership immediately — there's no automated verification, so use the note
-      below (and the profile's public page) to judge legitimacy.
+      ownership immediately. A "GitHub verified" badge means the claimant's own
+      linked GitHub account was automatically confirmed to match this
+      developer's GitHub org/username — otherwise, use the note below (and the
+      profile's public page) to judge legitimacy yourself.
     </p>
 
     {
@@ -58,8 +60,11 @@ try {
           {claims.map((c) => (
             <li class="card space-y-3">
               <header>
-                <h2 class="font-semibold">
+                <h2 class="font-semibold flex items-center gap-2">
                   {c.developer_name} ({c.developer_id})
+                  {c.github_org_verified && (
+                    <span class="badge">GitHub verified</span>
+                  )}
                 </h2>
                 <p class="text-sm text-muted-foreground">
                   {c.developer_type} &middot; claimed by{' '}

--- a/src/pages/account/moderate/developers/index.astro
+++ b/src/pages/account/moderate/developers/index.astro
@@ -99,6 +99,9 @@ try {
                   <h2 class="font-semibold flex items-center gap-2">
                     {d.name} ({d.id})
                     {d.approved && <span class="badge">Approved</span>}
+                    {d.github_org_verified && (
+                      <span class="badge">GitHub verified</span>
+                    )}
                   </h2>
                   <p class="text-sm text-muted-foreground">
                     {d.type}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,13 +123,24 @@ export type DeveloperProfile = Developer & {
   // listUnapprovedDevelopers, listAllDevelopers) — only on the public
   // /developer/[id] read.
   unclaimed?: boolean;
+  // Server-computed at creation time only (api repo's
+  // DevelopersDatabase.verifyGithubOwnership()) — whether this id was
+  // confirmed to match the creator's own linked GitHub org/username.
+  // Moderator-review signal, not selected by the public /developer/[id]
+  // query (SELECT_DEVELOPER_PUBLIC in database.ts).
+  github_org_verified?: boolean;
+  github_verification_note?: string;
 };
 
 // Body for PUT /extensions/v2/developers/me — everything but the server-set
-// `approved` flag and `content_revision` (bumped by the api repo itself).
+// `approved` flag, `content_revision`, and GitHub verification fields.
 export type DeveloperProfileInput = Omit<
   DeveloperProfile,
-  'approved' | 'unclaimed' | 'content_revision'
+  | 'approved'
+  | 'unclaimed'
+  | 'content_revision'
+  | 'github_org_verified'
+  | 'github_verification_note'
 >;
 
 // What getDeveloperById (the public /developer/[id] read) returns —

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,6 +167,15 @@ export type DeveloperClaim = {
   reviewer_id?: string;
   created_at: string;
   reviewed_at?: string;
+  // Server-computed at claim time (api repo's claim()) — true when the
+  // claimant's own linked GitHub identity was confirmed to match this
+  // developer's GitHub org/username. Undefined when there was no verifiable
+  // GitHub entity for this id, or the claimant had no linked GitHub identity
+  // yet; both cases still require the moderator's own judgment call, same as
+  // before this existed. A positive mismatch is rejected before a claim can
+  // even be created, so this is never `false` in practice.
+  github_org_verified?: boolean;
+  github_verification_note?: string;
 };
 
 // DeveloperClaim plus the claimed profile's own name/type, for the moderator

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,12 +144,16 @@ export type DeveloperProfileInput = Omit<
 >;
 
 // What getDeveloperById (the public /developer/[id] read) returns —
-// contact_email is owner/moderator-only and content_revision is an internal
-// moderation concern, so both are excluded at the type level rather than
+// contact_email is owner/moderator-only, content_revision is an internal
+// moderation concern, and github_org_verified/github_verification_note are
+// a moderator-review signal — all excluded at the type level rather than
 // relying solely on the query not selecting them.
 export type PublicDeveloperProfile = Omit<
   DeveloperProfile,
-  'contact_email' | 'content_revision'
+  | 'contact_email'
+  | 'content_revision'
+  | 'github_org_verified'
+  | 'github_verification_note'
 >;
 
 // A snapshot of a developers row as it existed right after one


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds GitHub-based verification to developer profiles and claims, and improves the create/claim flow. Moderators see a “GitHub verified” badge, and users are only guided to claim when a taken ID belongs to an unclaimed profile.

- **New Features**
  - Sync GitHub identity from auth on login and persist to `users` (`github_login`, `github_orgs`).
  - Auto-verify ownership when GitHub matches the developer ID (on create and on claim); expose `github_org_verified` and `github_verification_note` to moderators only; show a “GitHub verified” badge in developer and claim moderation lists.
  - When create fails because the ID exists on an unowned profile, show a link to claim it; detection uses the `DEVELOPER_ID_TAKEN` code and confirms the profile is unclaimed; add clearer helper text for the ID field.

- **Migration**
  - Run `0005_add_github_fields.sql` to add `github_login` and `github_orgs` to `users`.
  - Ensure the auth service requests the `read:org` scope so OIDC claims populate.

<sup>Written for commit 181d0d036bc2d1daab7a6a01c72a390b3c5227b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

