### PR TITLE
Show GitHub reconnect and claim status on account

### DIFF
--- a/src/components/DetailsCard.astro
+++ b/src/components/DetailsCard.astro
@@ -102,7 +102,8 @@ const details: DetailsItem[] = [
                 </a>
               ) : (
                 <span
-                  class={`badge-outline text-xs ${badgeColorClasses[detail.color]}`}
+                  class={`badge text-xs ${badgeColorClasses[detail.color]}`}
+                  data-variant="outline"
                 >
                   {detail.text}
                 </span>

--- a/src/components/ExtensionSubmissionForm.astro
+++ b/src/components/ExtensionSubmissionForm.astro
@@ -1,6 +1,7 @@
 ---
 import { EXTENSION_TYPES, SOURCE_TYPES } from '@/types';
 import type { Developer, Extension } from '@/types';
+import { CircleAlert } from '@lucide/astro';
 
 interface Props {
   developer: Developer;
@@ -15,22 +16,23 @@ const isEdit = Boolean(extension);
 <form method="POST" class="space-y-8">
   {
     error && (
-      <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-        {error}
+      <div class="alert" data-variant="destructive">
+        <CircleAlert class="size-4" />
+        <section>{error}</section>
       </div>
     )
   }
 
   <fieldset class="fieldset space-y-4">
-    <legend class="font-semibold mb-2">Publisher</legend>
-    <p class="text-sm text-muted-foreground">
+    <legend>Publisher</legend>
+    <p>
       Publishing as <strong>{developer.name}</strong> ({developer.id}).
       <a href="/account/developer">Edit Developer Profile</a>
     </p>
   </fieldset>
 
   <fieldset class="fieldset space-y-4">
-    <legend class="font-semibold mb-2">Extension</legend>
+    <legend>Extension</legend>
     <div class="field">
       <label for="extension_id">Extension ID</label>
       <input
@@ -43,13 +45,7 @@ const isEdit = Boolean(extension);
         value={extension?.id}
         readonly={isEdit}
       />
-      {
-        isEdit && (
-          <p class="text-sm text-muted-foreground">
-            The ID can't be changed after submission.
-          </p>
-        )
-      }
+      {isEdit && <p>The ID can't be changed after submission.</p>}
     </div>
     <div class="field">
       <label for="type">Type</label>
@@ -120,7 +116,7 @@ const isEdit = Boolean(extension);
   </fieldset>
 
   <fieldset class="fieldset space-y-4">
-    <legend class="font-semibold mb-2">License</legend>
+    <legend>License</legend>
     <div class="field">
       <label for="license_name">License Name</label>
       <input
@@ -145,7 +141,7 @@ const isEdit = Boolean(extension);
   </fieldset>
 
   <fieldset class="fieldset space-y-4">
-    <legend class="font-semibold mb-2">Source</legend>
+    <legend>Source</legend>
     <div class="field">
       <label for="source_type">Repository Host</label>
       <select class="select" id="source_type" name="source_type">
@@ -175,7 +171,7 @@ const isEdit = Boolean(extension);
   {
     isEdit && extension && extension.releases.length > 0 && (
       <fieldset class="fieldset space-y-2">
-        <legend class="font-semibold mb-2">Existing Releases</legend>
+        <legend>Existing Releases</legend>
         <ul class="text-sm text-muted-foreground space-y-1">
           {extension.releases.map((r) => (
             <li>
@@ -189,7 +185,7 @@ const isEdit = Boolean(extension);
   }
 
   <fieldset class="fieldset space-y-4">
-    <legend class="font-semibold mb-2">
+    <legend>
       {isEdit ? 'Add a new release (optional)' : 'Initial release'}
     </legend>
     <div class="field">

--- a/src/components/RejectDialog.astro
+++ b/src/components/RejectDialog.astro
@@ -1,0 +1,70 @@
+---
+import { X } from '@lucide/astro';
+
+interface Props {
+  id: string;
+  title: string;
+  description: string;
+  formAction: string;
+  reasonPlaceholder?: string;
+}
+
+const {
+  id,
+  title,
+  description,
+  formAction,
+  reasonPlaceholder = 'Reason for rejecting',
+} = Astro.props;
+---
+
+<dialog
+  id={id}
+  class="dialog"
+  aria-labelledby={`${id}-title`}
+  aria-describedby={`${id}-description`}
+  onclick="if (event.target === this) this.close()"
+>
+  <form method="POST" action={formAction}>
+    <header>
+      <h2 id={`${id}-title`}>{title}</h2>
+      <p id={`${id}-description`}>{description}</p>
+    </header>
+    <section>
+      <div class="field">
+        <label for={`${id}-note`}>Reason</label>
+        <input
+          class="input"
+          type="text"
+          id={`${id}-note`}
+          name="review_note"
+          placeholder={reasonPlaceholder}
+          required
+        />
+      </div>
+    </section>
+    <footer>
+      <button
+        type="button"
+        class="btn"
+        data-variant="outline"
+        onclick="this.closest('dialog').close()"
+      >
+        Cancel
+      </button>
+      <button type="submit" class="btn" data-variant="destructive">
+        Reject
+      </button>
+    </footer>
+    <button
+      type="button"
+      class="btn"
+      data-variant="ghost"
+      data-size="icon-sm"
+      aria-label="Close dialog"
+      onclick="this.closest('dialog').close()"
+    >
+      <X class="size-4" />
+    </button>
+  </form>
+</dialog>

--- a/src/components/ReleasesTable.astro
+++ b/src/components/ReleasesTable.astro
@@ -16,10 +16,10 @@ const releases = sortReleasesDescending(ext.releases);
 <div>
   <div class="flex items-center justify-between">
     <h2 class="text-xl font-semibold">Releases</h2>
-    <span class="badge-secondary">{releases.length}</span>
+    <span class="badge" data-variant="secondary">{releases.length}</span>
   </div>
 
-  <div class="overflow-x-auto mt-6">
+  <div class="table-container mt-6">
     <table class="table">
       <caption class="sr-only">Releases for {ext.name}</caption>
       <thead>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,7 +3,15 @@ import '@/styles/global.css';
 import LogoLight from '@/assets/logo-light.svg';
 import LogoDark from '@/assets/logo-dark.svg';
 import Container from '@/components/Container.astro';
-import { Sun, Moon, LogIn, LogOut, CircleUser } from '@lucide/astro';
+import {
+  Sun,
+  Moon,
+  LogIn,
+  LogOut,
+  CircleUser,
+  CircleAlert,
+  CircleCheck,
+} from '@lucide/astro';
 import { env } from 'cloudflare:workers';
 import { getSessionUser } from '@/lib/session';
 
@@ -74,7 +82,7 @@ const user = await getSessionUser(Astro.cookies, env.SESSION_SECRET);
             class="ml-3 pl-3 border-s text-sm font-semibold uppercase tracking-wider"
             >Extensions</span
           >
-          <span class="ml-2 badge-secondary">beta</span>
+          <span class="ml-2 badge" data-variant="secondary">beta</span>
         </div>
         <div class="flex items-center gap-3">
           {
@@ -143,15 +151,17 @@ const user = await getSessionUser(Astro.cookies, env.SESSION_SECRET);
       <Container class="py-6 sm:py-10">
         {
           Astro.url.searchParams.get('auth_error') && (
-            <div class="mb-6 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-              Sign-in failed. Please try again.
+            <div class="alert mb-6" data-variant="destructive">
+              <CircleAlert class="size-4" />
+              <section>Sign-in failed. Please try again.</section>
             </div>
           )
         }
         {
           Astro.url.searchParams.get('account_deleted') && (
-            <div class="mb-6 rounded-md border border-border bg-muted px-4 py-3 text-sm">
-              Your account has been deleted.
+            <div class="alert mb-6">
+              <CircleCheck class="size-4" />
+              <section>Your account has been deleted.</section>
             </div>
           )
         }

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -156,3 +156,16 @@ export function createApiClient(env: Cloudflare.Env, sub: string) {
       }),
   };
 }
+
+// Claim status is a nice-to-have on the account pages, not essential — a
+// failure here shouldn't break the page, so callers get an empty list back
+// instead of having to duplicate this fallback themselves.
+export async function listMyClaimsSafely(
+  api: ReturnType<typeof createApiClient>,
+): Promise<DeveloperClaim[]> {
+  try {
+    return await api.listMyClaims();
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -3,7 +3,7 @@
 // Roles, permissions, and extension ownership are modeled in this app's own
 // database (see users.ts), never requested from or trusted to the auth service.
 
-const ISSUER = 'https://auth.fossbilling.net';
+export const ISSUER = 'https://auth.fossbilling.net';
 const AUTHORIZE_ENDPOINT = `${ISSUER}/oauth2/authorize`;
 const TOKEN_ENDPOINT = `${ISSUER}/oauth2/token`;
 const USERINFO_ENDPOINT = `${ISSUER}/oauth2/userinfo`;

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -57,6 +57,22 @@ export async function isModerator(
   return row?.is_moderator === 1;
 }
 
+// True once a user has signed in via GitHub since the auth service started
+// requesting read:org (see oauth.ts's UserInfo type) — used to prompt
+// existing accounts that signed in before that change to reconnect, since
+// their developer-profile claims otherwise fall back to unverified/manual
+// review indefinitely.
+export async function hasLinkedGithub(
+  db: D1Database,
+  userId: string,
+): Promise<boolean> {
+  const row = await db
+    .prepare('SELECT github_login FROM users WHERE id = ?')
+    .bind(userId)
+    .first<{ github_login: string | null }>();
+  return Boolean(row?.github_login);
+}
+
 export async function deleteUser(
   db: D1Database,
   userId: string,

--- a/src/pages/account/delete.astro
+++ b/src/pages/account/delete.astro
@@ -67,30 +67,33 @@ if (Astro.request.method === 'POST' && extensions.length === 0) {
           deleting your account.
         </p>
       ) : (
-        <div class="card space-y-4">
-          <p class="text-sm text-muted-foreground">
-            This permanently deletes your account
-            {developer && ' and your developer profile'}. This can't be undone.
-          </p>
-          <ul class="text-sm text-muted-foreground list-disc pl-5 space-y-1">
-            <li>Your personal profile (display name) is removed.</li>
-            {developer && (
-              <li>
-                Your developer profile ({developer.name}) and its public page
-                are removed; the ID may be used by someone else afterward.
-              </li>
-            )}
-          </ul>
-          <div class="flex justify-end gap-3">
-            <a href="/account" class="btn" data-variant="ghost">
-              Cancel
-            </a>
-            <form method="POST">
-              <button type="submit" class="btn" data-variant="destructive">
-                Permanently Delete My Account
-              </button>
-            </form>
-          </div>
+        <div class="card">
+          <section class="space-y-4">
+            <p class="text-sm text-muted-foreground">
+              This permanently deletes your account
+              {developer && ' and your developer profile'}. This can't be
+              undone.
+            </p>
+            <ul class="text-sm text-muted-foreground list-disc pl-5 space-y-1">
+              <li>Your personal profile (display name) is removed.</li>
+              {developer && (
+                <li>
+                  Your developer profile ({developer.name}) and its public page
+                  are removed; the ID may be used by someone else afterward.
+                </li>
+              )}
+            </ul>
+            <div class="flex justify-end gap-3">
+              <a href="/account" class="btn" data-variant="ghost">
+                Cancel
+              </a>
+              <form method="POST">
+                <button type="submit" class="btn" data-variant="destructive">
+                  Permanently Delete My Account
+                </button>
+              </form>
+            </div>
+          </section>
         </div>
       )
     }

--- a/src/pages/account/delete.astro
+++ b/src/pages/account/delete.astro
@@ -6,6 +6,7 @@ import { createApiClient, ApiRequestError } from '@/lib/apiClient';
 import { getDeveloperByOwner, getExtensionsByOwner } from '@/lib/database';
 import { deleteUser } from '@/lib/users';
 import { SESSION_COOKIE } from '@/lib/session';
+import { CircleAlert } from '@lucide/astro';
 
 const guard = await requireUser(Astro, env);
 if (guard instanceof Response) return guard;
@@ -49,8 +50,9 @@ if (Astro.request.method === 'POST' && extensions.length === 0) {
 
     {
       error && (
-        <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>{error}</section>
         </div>
       )
     }

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -13,6 +13,7 @@ import {
   DeveloperValidationError,
 } from '@/lib/developer-form';
 import { DEVELOPER_TYPES } from '@/types';
+import { CircleAlert } from '@lucide/astro';
 import type {
   DeveloperClaim,
   DeveloperProfileInput,
@@ -140,11 +141,13 @@ if (!isEdit) {
               <li class="text-sm flex items-center justify-between gap-3">
                 <code>{c.developer_id}</code>
                 {c.status === 'pending' && (
-                  <span class="badge-secondary">Pending Review</span>
+                  <span class="badge" data-variant="secondary">
+                    Pending Review
+                  </span>
                 )}
                 {c.status === 'approved' && <span class="badge">Approved</span>}
                 {c.status === 'rejected' && (
-                  <span class="badge-secondary">
+                  <span class="badge" data-variant="destructive">
                     Rejected{c.review_note ? `: ${c.review_note}` : ''}
                   </span>
                 )}
@@ -171,7 +174,9 @@ if (!isEdit) {
               {developer!.approved ? (
                 <span class="badge">Approved</span>
               ) : (
-                <span class="badge-secondary">Not Yet Reviewed</span>
+                <span class="badge" data-variant="secondary">
+                  Not Yet Reviewed
+                </span>
               )}
             </p>
           </div>
@@ -189,25 +194,28 @@ if (!isEdit) {
 
     {
       error && (
-        <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          <p>{error}</p>
-          {idTaken && submitted?.id && (
-            <p class="mt-2">
-              If this is your existing extension author profile, you can request
-              to claim it instead of creating a new one — visit{' '}
-              <a href={`/developer/${submitted.id}`} class="underline">
-                the public profile page for "{submitted.id}"
-              </a>{' '}
-              and use the "Claim this profile" option.
-            </p>
-          )}
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>
+            <p>{error}</p>
+            {idTaken && submitted?.id && (
+              <p>
+                If this is your existing extension author profile, you can
+                request to claim it instead of creating a new one — visit{' '}
+                <a href={`/developer/${submitted.id}`} class="underline">
+                  the public profile page for "{submitted.id}"
+                </a>{' '}
+                and use the "Claim this profile" option.
+              </p>
+            )}
+          </section>
         </div>
       )
     }
 
     <form method="POST" class="space-y-8">
       <fieldset class="fieldset space-y-4">
-        <legend class="font-semibold mb-2">Publisher Identity</legend>
+        <legend>Publisher Identity</legend>
         <div class="field">
           <label for="id">Publisher ID</label>
           <input
@@ -223,11 +231,9 @@ if (!isEdit) {
           />
           {
             isEdit ? (
-              <p class="text-sm text-muted-foreground">
-                The ID can't be changed after it's created.
-              </p>
+              <p>The ID can't be changed after it's created.</p>
             ) : (
-              <p class="text-sm text-muted-foreground">
+              <p>
                 Typically your GitHub organization or username — this is used to
                 verify ownership if you (or someone else) later try to claim
                 this profile.
@@ -271,8 +277,8 @@ if (!isEdit) {
       </fieldset>
 
       <fieldset class="fieldset space-y-4">
-        <legend class="font-semibold mb-2">Public Profile</legend>
-        <p class="text-sm text-muted-foreground -mt-2">
+        <legend>Public Profile</legend>
+        <p>
           Shown on your public developer page at
           {developer ? ` /developer/${developer.id}` : ' /developer/<your-id>'}.
         </p>
@@ -289,7 +295,7 @@ if (!isEdit) {
       </fieldset>
 
       <fieldset class="fieldset space-y-4">
-        <legend class="font-semibold mb-2">Private contact</legend>
+        <legend>Private contact</legend>
         <div class="field">
           <label for="contact_email">Contact Email (Optional)</label>
           <input
@@ -299,7 +305,7 @@ if (!isEdit) {
             name="contact_email"
             value={fields?.contact_email}
           />
-          <p class="text-sm text-muted-foreground">
+          <p>
             Never shown publicly — only visible to FOSSBilling moderators, in
             case they need to reach you about this profile or its extensions.
           </p>

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -134,60 +134,68 @@ if (!isEdit) {
 
     {
       !isEdit && myClaims.length > 0 && (
-        <div class="card space-y-2">
-          <h2 class="font-semibold">Your Profile Claims</h2>
-          <ul class="space-y-2">
-            {myClaims.map((c) => (
-              <li class="text-sm flex items-center justify-between gap-3">
-                <code>{c.developer_id}</code>
-                {c.status === 'pending' && (
-                  <span class="badge" data-variant="secondary">
-                    Pending Review
-                  </span>
-                )}
-                {c.status === 'approved' && <span class="badge">Approved</span>}
-                {c.status === 'rejected' && (
-                  <span class="badge" data-variant="destructive">
-                    Rejected{c.review_note ? `: ${c.review_note}` : ''}
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
+        <div class="card">
+          <header>
+            <h2 class="font-semibold">Your Profile Claims</h2>
+          </header>
+          <section>
+            <ul class="space-y-2">
+              {myClaims.map((c) => (
+                <li class="text-sm flex items-center justify-between gap-3">
+                  <code>{c.developer_id}</code>
+                  {c.status === 'pending' && (
+                    <span class="badge" data-variant="secondary">
+                      Pending Review
+                    </span>
+                  )}
+                  {c.status === 'approved' && (
+                    <span class="badge">Approved</span>
+                  )}
+                  {c.status === 'rejected' && (
+                    <span class="badge" data-variant="destructive">
+                      Rejected{c.review_note ? `: ${c.review_note}` : ''}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
         </div>
       )
     }
 
     {
       isEdit && (
-        <div class="card flex items-center gap-4">
-          {developer!.avatar_url && (
-            <img
-              src={developer!.avatar_url}
-              alt=""
-              class="w-14 h-14 rounded-full object-cover"
-            />
-          )}
-          <div class="flex-1">
-            <p class="font-medium flex items-center gap-2">
-              {developer!.name}
-              {developer!.approved ? (
-                <span class="badge">Approved</span>
-              ) : (
-                <span class="badge" data-variant="secondary">
-                  Not Yet Reviewed
-                </span>
-              )}
-            </p>
-          </div>
-          <a
-            href={`/developer/${developer!.id}`}
-            class="btn"
-            data-size="sm"
-            data-variant="outline"
-          >
-            View Public Profile
-          </a>
+        <div class="card">
+          <section class="flex items-center gap-4">
+            {developer!.avatar_url && (
+              <img
+                src={developer!.avatar_url}
+                alt=""
+                class="w-14 h-14 rounded-full object-cover"
+              />
+            )}
+            <div class="flex-1">
+              <p class="font-medium flex items-center gap-2">
+                {developer!.name}
+                {developer!.approved ? (
+                  <span class="badge">Approved</span>
+                ) : (
+                  <span class="badge" data-variant="secondary">
+                    Not Yet Reviewed
+                  </span>
+                )}
+              </p>
+            </div>
+            <a
+              href={`/developer/${developer!.id}`}
+              class="btn"
+              data-size="sm"
+              data-variant="outline"
+            >
+              View Public Profile
+            </a>
+          </section>
         </div>
       )
     }
@@ -322,98 +330,107 @@ if (!isEdit) {
 
     {
       isEdit && (
-        <div class="card space-y-3">
-          <h2 class="font-semibold">Transfer Ownership</h2>
-          <p class="text-sm text-muted-foreground">
-            Generate a one-time link to hand this profile to a different
-            account. It works once and expires after 24 hours — generating a new
-            link invalidates any earlier one for this profile.
-          </p>
-
-          {Astro.url.searchParams.get('transfer_revoked') && (
+        <div class="card">
+          <header>
+            <h2 class="font-semibold">Transfer Ownership</h2>
+          </header>
+          <section class="space-y-3">
             <p class="text-sm text-muted-foreground">
-              Pending transfer link revoked.
+              Generate a one-time link to hand this profile to a different
+              account. It works once and expires after 24 hours — generating a
+              new link invalidates any earlier one for this profile.
             </p>
-          )}
-          {Astro.url.searchParams.get('transfer_accepted') && (
-            <p class="text-sm text-muted-foreground">
-              You've accepted a transfer — this profile is now yours.
-            </p>
-          )}
 
-          {transferResult && (
-            <div class="rounded-md border px-4 py-3 text-sm space-y-2">
-              <p class="font-medium">
-                Share this link with the new owner — it won't be shown again:
-              </p>
-              <code class="block break-all bg-muted p-2 rounded">
-                {`${Astro.url.origin}/account/developer/transfer/${transferResult.token}`}
-              </code>
-              <p class="text-muted-foreground">
-                Expires {new Date(transferResult.expires_at).toLocaleString()}.
-              </p>
-            </div>
-          )}
-
-          <div class="flex gap-3">
-            <form method="POST">
-              <input type="hidden" name="intent" value="transfer-initiate" />
-              <button
-                type="submit"
-                class="btn"
-                data-size="sm"
-                data-variant="outline"
-              >
-                Generate Transfer Link
-              </button>
-            </form>
-            <form method="POST" action="/account/developer/transfer/revoke">
-              <button
-                type="submit"
-                class="btn"
-                data-size="sm"
-                data-variant="ghost"
-              >
-                Revoke Pending Link
-              </button>
-            </form>
-          </div>
-        </div>
-      )
-    }
-
-    {
-      isEdit && (
-        <div class="card space-y-3">
-          <h2 class="font-semibold text-destructive">
-            Delete Developer Profile
-          </h2>
-          {extensions.length > 0 ? (
-            <p class="text-sm text-muted-foreground">
-              You have {extensions.length} published extension
-              {extensions.length === 1 ? '' : 's'} under this profile. Transfer
-              ownership or remove them before deleting it.
-            </p>
-          ) : (
-            <>
+            {Astro.url.searchParams.get('transfer_revoked') && (
               <p class="text-sm text-muted-foreground">
-                Permanently deletes your publisher identity (name, contact info)
-                and its public page. This can't be undone, and the ID may be
-                used by someone else afterward.
+                Pending transfer link revoked.
               </p>
+            )}
+            {Astro.url.searchParams.get('transfer_accepted') && (
+              <p class="text-sm text-muted-foreground">
+                You've accepted a transfer — this profile is now yours.
+              </p>
+            )}
+
+            {transferResult && (
+              <div class="rounded-md border px-4 py-3 text-sm space-y-2">
+                <p class="font-medium">
+                  Share this link with the new owner — it won't be shown again:
+                </p>
+                <code class="block break-all bg-muted p-2 rounded">
+                  {`${Astro.url.origin}/account/developer/transfer/${transferResult.token}`}
+                </code>
+                <p class="text-muted-foreground">
+                  Expires {new Date(transferResult.expires_at).toLocaleString()}
+                  .
+                </p>
+              </div>
+            )}
+
+            <div class="flex gap-3">
               <form method="POST">
-                <input type="hidden" name="intent" value="delete" />
+                <input type="hidden" name="intent" value="transfer-initiate" />
                 <button
                   type="submit"
                   class="btn"
                   data-size="sm"
                   data-variant="outline"
                 >
-                  Delete Developer Profile
+                  Generate Transfer Link
                 </button>
               </form>
-            </>
-          )}
+              <form method="POST" action="/account/developer/transfer/revoke">
+                <button
+                  type="submit"
+                  class="btn"
+                  data-size="sm"
+                  data-variant="ghost"
+                >
+                  Revoke Pending Link
+                </button>
+              </form>
+            </div>
+          </section>
+        </div>
+      )
+    }
+
+    {
+      isEdit && (
+        <div class="card">
+          <header>
+            <h2 class="font-semibold text-destructive">
+              Delete Developer Profile
+            </h2>
+          </header>
+          <section class="space-y-3">
+            {extensions.length > 0 ? (
+              <p class="text-sm text-muted-foreground">
+                You have {extensions.length} published extension
+                {extensions.length === 1 ? '' : 's'} under this profile.
+                Transfer ownership or remove them before deleting it.
+              </p>
+            ) : (
+              <>
+                <p class="text-sm text-muted-foreground">
+                  Permanently deletes your publisher identity (name, contact
+                  info) and its public page. This can't be undone, and the ID
+                  may be used by someone else afterward.
+                </p>
+                <form method="POST">
+                  <input type="hidden" name="intent" value="delete" />
+                  <button
+                    type="submit"
+                    class="btn"
+                    data-size="sm"
+                    data-variant="outline"
+                  >
+                    Delete Developer Profile
+                  </button>
+                </form>
+              </>
+            )}
+          </section>
         </div>
       )
     }

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -2,7 +2,11 @@
 import Base from '../../../layouts/Base.astro';
 import { env } from 'cloudflare:workers';
 import { requireUser } from '@/lib/auth-guard';
-import { createApiClient, ApiRequestError } from '@/lib/apiClient';
+import {
+  createApiClient,
+  ApiRequestError,
+  listMyClaimsSafely,
+} from '@/lib/apiClient';
 import {
   getDeveloperByOwner,
   getDeveloperById,
@@ -112,14 +116,7 @@ if (Astro.request.method === 'POST') {
 // off the real (saved) `developer`, not a failed, unsaved submission.
 const fields = submitted ?? developer;
 
-let myClaims: DeveloperClaim[] = [];
-if (!isEdit) {
-  try {
-    myClaims = await api.listMyClaims();
-  } catch {
-    // non-fatal — just don't show claim status
-  }
-}
+const myClaims: DeveloperClaim[] = isEdit ? [] : await listMyClaimsSafely(api);
 ---
 
 <Base title="Developer Profile — FOSSBilling Extensions">

--- a/src/pages/account/developer/transfer/[token].astro
+++ b/src/pages/account/developer/transfer/[token].astro
@@ -3,6 +3,7 @@ import Base from '../../../../layouts/Base.astro';
 import { env } from 'cloudflare:workers';
 import { requireUser } from '@/lib/auth-guard';
 import { createApiClient, ApiRequestError } from '@/lib/apiClient';
+import { CircleAlert } from '@lucide/astro';
 
 const guard = await requireUser(Astro, env);
 if (guard instanceof Response) return guard;
@@ -42,8 +43,9 @@ if (Astro.request.method === 'POST') {
 
     {
       error && (
-        <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>{error}</section>
         </div>
       )
     }

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -4,19 +4,23 @@ import { env } from 'cloudflare:workers';
 import { requireUser } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import { getDeveloperByOwner, getExtensionsByOwner } from '@/lib/database';
-import { isModerator } from '@/lib/users';
+import { isModerator, hasLinkedGithub } from '@/lib/users';
+import { ISSUER } from '@/lib/oauth';
 import { getLatestRelease } from '@/types';
-import type { Submission } from '@/types';
+import type { DeveloperClaim, Submission } from '@/types';
 
 const guard = await requireUser(Astro, env);
 if (guard instanceof Response) return guard;
 const user = guard;
 
-const [ownedExtensions, moderator, developer] = await Promise.all([
-  getExtensionsByOwner(env.DB_EXTENSIONS, user.sub),
-  isModerator(env.DB_EXTENSIONS, user.sub),
-  getDeveloperByOwner(env.DB_EXTENSIONS, user.sub),
-]);
+const [ownedExtensions, moderator, developer, githubLinked] = await Promise.all(
+  [
+    getExtensionsByOwner(env.DB_EXTENSIONS, user.sub),
+    isModerator(env.DB_EXTENSIONS, user.sub),
+    getDeveloperByOwner(env.DB_EXTENSIONS, user.sub),
+    hasLinkedGithub(env.DB_EXTENSIONS, user.sub),
+  ],
+);
 
 const banner: Record<string, string> = {
   submitted: 'Submitted for Review.',
@@ -39,6 +43,19 @@ try {
 } catch {
   submissionsError = true;
 }
+
+let myClaims: DeveloperClaim[] = [];
+if (!developer) {
+  try {
+    myClaims = await api.listMyClaims();
+  } catch {
+    // non-fatal — just don't show claim status
+  }
+}
+// listMyClaims returns newest first; approved claims transfer ownership
+// immediately (developer becomes truthy), so only pending/rejected ever
+// surface here.
+const latestClaim = myClaims[0];
 
 const statusBadgeClass: Record<Submission['status'], string> = {
   pending: 'badge-secondary',
@@ -83,6 +100,25 @@ const statusBadgeClass: Record<Submission['status'], string> = {
       )
     }
 
+    {
+      !githubLinked && (
+        <div class="rounded-md border border-border bg-muted px-4 py-3 text-sm flex items-center justify-between gap-3">
+          <p>
+            Grant GitHub organisation access so profile claims can be verified
+            automatically.
+          </p>
+          <a
+            href={`${ISSUER}/account`}
+            class="btn"
+            data-size="sm"
+            data-variant="outline"
+          >
+            Reconnect GitHub
+          </a>
+        </div>
+      )
+    }
+
     <section class="card">
       <header class="flex items-center justify-between">
         <h2 class="font-semibold">Developer Profile</h2>
@@ -104,6 +140,21 @@ const statusBadgeClass: Record<Submission['status'], string> = {
                 <span class="badge">Approved</span>
               ) : (
                 <span class="badge-secondary">Not Yet Reviewed</span>
+              )}
+            </p>
+          ) : latestClaim ? (
+            <p class="text-sm flex items-center gap-2">
+              Claim on <strong>{latestClaim.developer_id}</strong>
+              {latestClaim.status === 'pending' && (
+                <span class="badge-secondary">Pending Review</span>
+              )}
+              {latestClaim.status === 'rejected' && (
+                <span class="badge-secondary">
+                  Rejected
+                  {latestClaim.review_note
+                    ? `: ${latestClaim.review_note}`
+                    : ''}
+                </span>
               )}
             </p>
           ) : (

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -8,6 +8,7 @@ import { isModerator, hasLinkedGithub } from '@/lib/users';
 import { ISSUER } from '@/lib/oauth';
 import { getLatestRelease } from '@/types';
 import type { DeveloperClaim, Submission } from '@/types';
+import { CircleCheck } from '@lucide/astro';
 
 const guard = await requireUser(Astro, env);
 if (guard instanceof Response) return guard;
@@ -57,10 +58,10 @@ if (!developer) {
 // surface here.
 const latestClaim = myClaims[0];
 
-const statusBadgeClass: Record<Submission['status'], string> = {
-  pending: 'badge-secondary',
-  approved: 'badge',
-  rejected: 'badge-outline text-destructive',
+const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
+  pending: 'secondary',
+  approved: undefined,
+  rejected: 'destructive',
 };
 ---
 
@@ -94,27 +95,31 @@ const statusBadgeClass: Record<Submission['status'], string> = {
 
     {
       bannerKey && (
-        <div class="rounded-md border border-border bg-muted px-4 py-3 text-sm">
-          {banner[bannerKey]}
+        <div class="alert">
+          <CircleCheck class="size-4" />
+          <section>{banner[bannerKey]}</section>
         </div>
       )
     }
 
     {
       !githubLinked && (
-        <div class="rounded-md border border-border bg-muted px-4 py-3 text-sm flex items-center justify-between gap-3">
-          <p>
-            Grant GitHub organisation access so profile claims can be verified
+        <div class="alert">
+          <h2>Reconnect GitHub</h2>
+          <section>
+            Grant GitHub organization access so profile claims can be verified
             automatically.
-          </p>
-          <a
-            href={`${ISSUER}/account`}
-            class="btn"
-            data-size="sm"
-            data-variant="outline"
-          >
-            Reconnect GitHub
-          </a>
+          </section>
+          <footer>
+            <a
+              href={`${ISSUER}/account`}
+              class="btn"
+              data-size="sm"
+              data-variant="outline"
+            >
+              Reconnect GitHub
+            </a>
+          </footer>
         </div>
       )
     }
@@ -139,17 +144,21 @@ const statusBadgeClass: Record<Submission['status'], string> = {
               {developer.approved ? (
                 <span class="badge">Approved</span>
               ) : (
-                <span class="badge-secondary">Not Yet Reviewed</span>
+                <span class="badge" data-variant="secondary">
+                  Not Yet Reviewed
+                </span>
               )}
             </p>
           ) : latestClaim ? (
             <p class="text-sm flex items-center gap-2">
               Claim on <strong>{latestClaim.developer_id}</strong>
               {latestClaim.status === 'pending' && (
-                <span class="badge-secondary">Pending Review</span>
+                <span class="badge" data-variant="secondary">
+                  Pending Review
+                </span>
               )}
               {latestClaim.status === 'rejected' && (
-                <span class="badge-secondary">
+                <span class="badge" data-variant="destructive">
                   Rejected
                   {latestClaim.review_note
                     ? `: ${latestClaim.review_note}`
@@ -247,7 +256,12 @@ const statusBadgeClass: Record<Submission['status'], string> = {
                       </p>
                     )}
                   </div>
-                  <span class={statusBadgeClass[s.status]}>{s.status}</span>
+                  <span
+                    class="badge"
+                    data-variant={statusBadgeVariant[s.status]}
+                  >
+                    {s.status}
+                  </span>
                 </li>
               ))}
             </ul>

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -2,7 +2,7 @@
 import Base from '../../layouts/Base.astro';
 import { env } from 'cloudflare:workers';
 import { requireUser } from '@/lib/auth-guard';
-import { createApiClient } from '@/lib/apiClient';
+import { createApiClient, listMyClaimsSafely } from '@/lib/apiClient';
 import { getDeveloperByOwner, getExtensionsByOwner } from '@/lib/database';
 import { isModerator, hasLinkedGithub } from '@/lib/users';
 import { ISSUER } from '@/lib/oauth';
@@ -45,14 +45,9 @@ try {
   submissionsError = true;
 }
 
-let myClaims: DeveloperClaim[] = [];
-if (!developer) {
-  try {
-    myClaims = await api.listMyClaims();
-  } catch {
-    // non-fatal — just don't show claim status
-  }
-}
+const myClaims: DeveloperClaim[] = developer
+  ? []
+  : await listMyClaimsSafely(api);
 // listMyClaims returns newest first; approved claims transfer ownership
 // immediately (developer becomes truthy), so only pending/rejected ever
 // surface here.

--- a/src/pages/account/moderate/developers/[id]/history.astro
+++ b/src/pages/account/moderate/developers/[id]/history.astro
@@ -5,6 +5,7 @@ import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient, ApiRequestError } from '@/lib/apiClient';
 import { isSafeHttpUrl } from '@/lib/safe-url';
 import type { DeveloperHistoryEntry } from '@/types';
+import { CircleAlert } from '@lucide/astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -41,8 +42,9 @@ try {
 
     {
       loadError && (
-        <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {loadError}
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>{loadError}</section>
         </div>
       )
     }
@@ -63,7 +65,11 @@ try {
               <div class="flex items-center justify-between gap-4">
                 <p class="font-medium">
                   {entry.name}
-                  {i === 0 && <span class="badge-secondary ml-2">Current</span>}
+                  {i === 0 && (
+                    <span class="badge ml-2" data-variant="secondary">
+                      Current
+                    </span>
+                  )}
                 </p>
                 <time class="text-sm text-muted-foreground">
                   {new Date(entry.changed_at).toLocaleString()}

--- a/src/pages/account/moderate/developers/[id]/history.astro
+++ b/src/pages/account/moderate/developers/[id]/history.astro
@@ -62,7 +62,7 @@ try {
         <ol class="space-y-4">
           {entries.map((entry, i) => (
             <li class="card">
-              <div class="flex items-center justify-between gap-4">
+              <header class="flex items-center justify-between gap-4">
                 <p class="font-medium">
                   {entry.name}
                   {i === 0 && (
@@ -74,24 +74,26 @@ try {
                 <time class="text-sm text-muted-foreground">
                   {new Date(entry.changed_at).toLocaleString()}
                 </time>
-              </div>
-              <p class="text-sm text-muted-foreground mt-1">
-                {entry.type}
-                {entry.URL && (
-                  <>
-                    {' '}
-                    &middot;{' '}
-                    {isSafeHttpUrl(entry.URL) ? (
-                      <a href={entry.URL}>{entry.URL}</a>
-                    ) : (
-                      entry.URL
-                    )}
-                  </>
-                )}
-              </p>
-              <p class="text-sm text-muted-foreground mt-1">
-                Changed by <code>{entry.changed_by}</code>
-              </p>
+              </header>
+              <section>
+                <p class="text-sm text-muted-foreground">
+                  {entry.type}
+                  {entry.URL && (
+                    <>
+                      {' '}
+                      &middot;{' '}
+                      {isSafeHttpUrl(entry.URL) ? (
+                        <a href={entry.URL}>{entry.URL}</a>
+                      ) : (
+                        entry.URL
+                      )}
+                    </>
+                  )}
+                </p>
+                <p class="text-sm text-muted-foreground mt-1">
+                  Changed by <code>{entry.changed_by}</code>
+                </p>
+              </section>
             </li>
           ))}
         </ol>

--- a/src/pages/account/moderate/developers/claims/index.astro
+++ b/src/pages/account/moderate/developers/claims/index.astro
@@ -4,7 +4,7 @@ import { env } from 'cloudflare:workers';
 import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import type { PendingDeveloperClaim } from '@/types';
-import { CircleAlert } from '@lucide/astro';
+import { CircleAlert, X } from '@lucide/astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -75,7 +75,7 @@ try {
                 </p>
                 {c.note && <p class="text-sm mt-1">&ldquo;{c.note}&rdquo;</p>}
               </header>
-              <div class="flex items-center gap-3 flex-wrap">
+              <footer class="flex items-center gap-3 flex-wrap">
                 <form
                   method="POST"
                   action={`/account/moderate/developers/claims/${c.id}/approve`}
@@ -84,28 +84,78 @@ try {
                     Approve
                   </button>
                 </form>
+                <button
+                  type="button"
+                  class="btn"
+                  data-size="sm"
+                  data-variant="destructive"
+                  onclick={`document.getElementById('reject-claim-${c.id}').showModal()`}
+                >
+                  Reject
+                </button>
+              </footer>
+
+              <dialog
+                id={`reject-claim-${c.id}`}
+                class="dialog"
+                aria-labelledby={`reject-claim-${c.id}-title`}
+                aria-describedby={`reject-claim-${c.id}-description`}
+                onclick="if (event.target === this) this.close()"
+              >
                 <form
                   method="POST"
                   action={`/account/moderate/developers/claims/${c.id}/reject`}
-                  class="flex items-center gap-2"
                 >
-                  <input
-                    class="input"
-                    type="text"
-                    name="review_note"
-                    placeholder="Reason for rejecting (required)"
-                    required
-                  />
+                  <header>
+                    <h2 id={`reject-claim-${c.id}-title`}>
+                      Reject claim on "{c.developer_id}"?
+                    </h2>
+                    <p id={`reject-claim-${c.id}-description`}>
+                      The claimant will see this reason.
+                    </p>
+                  </header>
+                  <section>
+                    <div class="field">
+                      <label for={`reject-claim-${c.id}-note`}>Reason</label>
+                      <input
+                        class="input"
+                        type="text"
+                        id={`reject-claim-${c.id}-note`}
+                        name="review_note"
+                        placeholder="Reason for rejecting"
+                        required
+                      />
+                    </div>
+                  </section>
+                  <footer>
+                    <button
+                      type="button"
+                      class="btn"
+                      data-variant="outline"
+                      onclick="this.closest('dialog').close()"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      class="btn"
+                      data-variant="destructive"
+                    >
+                      Reject
+                    </button>
+                  </footer>
                   <button
-                    type="submit"
+                    type="button"
                     class="btn"
-                    data-size="sm"
-                    data-variant="destructive"
+                    data-variant="ghost"
+                    data-size="icon-sm"
+                    aria-label="Close dialog"
+                    onclick="this.closest('dialog').close()"
                   >
-                    Reject
+                    <X class="size-4" />
                   </button>
                 </form>
-              </div>
+              </dialog>
             </li>
           ))}
         </ul>

--- a/src/pages/account/moderate/developers/claims/index.astro
+++ b/src/pages/account/moderate/developers/claims/index.astro
@@ -4,6 +4,7 @@ import { env } from 'cloudflare:workers';
 import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import type { PendingDeveloperClaim } from '@/types';
+import { CircleAlert } from '@lucide/astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -32,8 +33,9 @@ try {
 
     {
       Astro.url.searchParams.get('error') && (
-        <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {Astro.url.searchParams.get('error')}
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>{Astro.url.searchParams.get('error')}</section>
         </div>
       )
     }

--- a/src/pages/account/moderate/developers/claims/index.astro
+++ b/src/pages/account/moderate/developers/claims/index.astro
@@ -4,7 +4,8 @@ import { env } from 'cloudflare:workers';
 import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import type { PendingDeveloperClaim } from '@/types';
-import { CircleAlert, X } from '@lucide/astro';
+import { CircleAlert } from '@lucide/astro';
+import RejectDialog from '@/components/RejectDialog.astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -95,67 +96,12 @@ try {
                 </button>
               </footer>
 
-              <dialog
+              <RejectDialog
                 id={`reject-claim-${c.id}`}
-                class="dialog"
-                aria-labelledby={`reject-claim-${c.id}-title`}
-                aria-describedby={`reject-claim-${c.id}-description`}
-                onclick="if (event.target === this) this.close()"
-              >
-                <form
-                  method="POST"
-                  action={`/account/moderate/developers/claims/${c.id}/reject`}
-                >
-                  <header>
-                    <h2 id={`reject-claim-${c.id}-title`}>
-                      Reject claim on "{c.developer_id}"?
-                    </h2>
-                    <p id={`reject-claim-${c.id}-description`}>
-                      The claimant will see this reason.
-                    </p>
-                  </header>
-                  <section>
-                    <div class="field">
-                      <label for={`reject-claim-${c.id}-note`}>Reason</label>
-                      <input
-                        class="input"
-                        type="text"
-                        id={`reject-claim-${c.id}-note`}
-                        name="review_note"
-                        placeholder="Reason for rejecting"
-                        required
-                      />
-                    </div>
-                  </section>
-                  <footer>
-                    <button
-                      type="button"
-                      class="btn"
-                      data-variant="outline"
-                      onclick="this.closest('dialog').close()"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      class="btn"
-                      data-variant="destructive"
-                    >
-                      Reject
-                    </button>
-                  </footer>
-                  <button
-                    type="button"
-                    class="btn"
-                    data-variant="ghost"
-                    data-size="icon-sm"
-                    aria-label="Close dialog"
-                    onclick="this.closest('dialog').close()"
-                  >
-                    <X class="size-4" />
-                  </button>
-                </form>
-              </dialog>
+                title={`Reject claim on "${c.developer_id}"?`}
+                description="The claimant will see this reason."
+                formAction={`/account/moderate/developers/claims/${c.id}/reject`}
+              />
             </li>
           ))}
         </ul>

--- a/src/pages/account/moderate/developers/index.astro
+++ b/src/pages/account/moderate/developers/index.astro
@@ -5,6 +5,7 @@ import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import { isSafeHttpUrl } from '@/lib/safe-url';
 import type { DeveloperProfile } from '@/types';
+import { CircleAlert } from '@lucide/astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -67,8 +68,9 @@ try {
 
     {
       Astro.url.searchParams.get('error') && (
-        <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {Astro.url.searchParams.get('error')}
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>{Astro.url.searchParams.get('error')}</section>
         </div>
       )
     }

--- a/src/pages/account/moderate/index.astro
+++ b/src/pages/account/moderate/index.astro
@@ -4,7 +4,8 @@ import { env } from 'cloudflare:workers';
 import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import type { Submission, SubmissionStatus } from '@/types';
-import { CircleAlert, X } from '@lucide/astro';
+import { CircleAlert } from '@lucide/astro';
+import RejectDialog from '@/components/RejectDialog.astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -116,69 +117,13 @@ try {
                 )}
 
                 {s.status === 'pending' && (
-                  <dialog
+                  <RejectDialog
                     id={`reject-submission-${s.id}`}
-                    class="dialog"
-                    aria-labelledby={`reject-submission-${s.id}-title`}
-                    aria-describedby={`reject-submission-${s.id}-description`}
-                    onclick="if (event.target === this) this.close()"
-                  >
-                    <form
-                      method="POST"
-                      action={`/account/moderate/${s.id}/reject`}
-                    >
-                      <header>
-                        <h2 id={`reject-submission-${s.id}-title`}>
-                          Reject "{s.payload.extension.name}"?
-                        </h2>
-                        <p id={`reject-submission-${s.id}-description`}>
-                          The submitter will see this reason.
-                        </p>
-                      </header>
-                      <section>
-                        <div class="field">
-                          <label for={`reject-submission-${s.id}-note`}>
-                            Reason
-                          </label>
-                          <input
-                            class="input"
-                            type="text"
-                            id={`reject-submission-${s.id}-note`}
-                            name="review_note"
-                            placeholder="Reason for rejection"
-                            required
-                          />
-                        </div>
-                      </section>
-                      <footer>
-                        <button
-                          type="button"
-                          class="btn"
-                          data-variant="outline"
-                          onclick="this.closest('dialog').close()"
-                        >
-                          Cancel
-                        </button>
-                        <button
-                          type="submit"
-                          class="btn"
-                          data-variant="destructive"
-                        >
-                          Reject
-                        </button>
-                      </footer>
-                      <button
-                        type="button"
-                        class="btn"
-                        data-variant="ghost"
-                        data-size="icon-sm"
-                        aria-label="Close dialog"
-                        onclick="this.closest('dialog').close()"
-                      >
-                        <X class="size-4" />
-                      </button>
-                    </form>
-                  </dialog>
+                    title={`Reject "${s.payload.extension.name}"?`}
+                    description="The submitter will see this reason."
+                    formAction={`/account/moderate/${s.id}/reject`}
+                    reasonPlaceholder="Reason for rejection"
+                  />
                 )}
                 {s.status !== 'pending' && s.review_note && (
                   <p class="text-sm text-muted-foreground mt-2">

--- a/src/pages/account/moderate/index.astro
+++ b/src/pages/account/moderate/index.astro
@@ -4,7 +4,7 @@ import { env } from 'cloudflare:workers';
 import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import type { Submission, SubmissionStatus } from '@/types';
-import { CircleAlert } from '@lucide/astro';
+import { CircleAlert, X } from '@lucide/astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -103,28 +103,82 @@ try {
                         Approve
                       </button>
                     </form>
+                    <button
+                      type="button"
+                      class="btn"
+                      data-size="sm"
+                      data-variant="destructive"
+                      onclick={`document.getElementById('reject-submission-${s.id}').showModal()`}
+                    >
+                      Reject
+                    </button>
+                  </div>
+                )}
+
+                {s.status === 'pending' && (
+                  <dialog
+                    id={`reject-submission-${s.id}`}
+                    class="dialog"
+                    aria-labelledby={`reject-submission-${s.id}-title`}
+                    aria-describedby={`reject-submission-${s.id}-description`}
+                    onclick="if (event.target === this) this.close()"
+                  >
                     <form
                       method="POST"
                       action={`/account/moderate/${s.id}/reject`}
-                      class="flex items-center gap-2 flex-1"
                     >
-                      <input
-                        class="input"
-                        type="text"
-                        name="review_note"
-                        placeholder="Reason for rejection (required)"
-                        required
-                      />
+                      <header>
+                        <h2 id={`reject-submission-${s.id}-title`}>
+                          Reject "{s.payload.extension.name}"?
+                        </h2>
+                        <p id={`reject-submission-${s.id}-description`}>
+                          The submitter will see this reason.
+                        </p>
+                      </header>
+                      <section>
+                        <div class="field">
+                          <label for={`reject-submission-${s.id}-note`}>
+                            Reason
+                          </label>
+                          <input
+                            class="input"
+                            type="text"
+                            id={`reject-submission-${s.id}-note`}
+                            name="review_note"
+                            placeholder="Reason for rejection"
+                            required
+                          />
+                        </div>
+                      </section>
+                      <footer>
+                        <button
+                          type="button"
+                          class="btn"
+                          data-variant="outline"
+                          onclick="this.closest('dialog').close()"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="submit"
+                          class="btn"
+                          data-variant="destructive"
+                        >
+                          Reject
+                        </button>
+                      </footer>
                       <button
-                        type="submit"
+                        type="button"
                         class="btn"
-                        data-size="sm"
-                        data-variant="destructive"
+                        data-variant="ghost"
+                        data-size="icon-sm"
+                        aria-label="Close dialog"
+                        onclick="this.closest('dialog').close()"
                       >
-                        Reject
+                        <X class="size-4" />
                       </button>
                     </form>
-                  </div>
+                  </dialog>
                 )}
                 {s.status !== 'pending' && s.review_note && (
                   <p class="text-sm text-muted-foreground mt-2">

--- a/src/pages/account/moderate/index.astro
+++ b/src/pages/account/moderate/index.astro
@@ -4,6 +4,7 @@ import { env } from 'cloudflare:workers';
 import { requireModerator } from '@/lib/auth-guard';
 import { createApiClient } from '@/lib/apiClient';
 import type { Submission, SubmissionStatus } from '@/types';
+import { CircleAlert } from '@lucide/astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -36,8 +37,9 @@ try {
 
     {
       Astro.url.searchParams.get('error') && (
-        <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {Astro.url.searchParams.get('error')}
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>{Astro.url.searchParams.get('error')}</section>
         </div>
       )
     }
@@ -77,7 +79,9 @@ try {
                     submitted {new Date(s.created_at).toLocaleString()}
                   </p>
                 </div>
-                <span class="badge-secondary">{s.payload.extension.type}</span>
+                <span class="badge" data-variant="secondary">
+                  {s.payload.extension.type}
+                </span>
               </header>
               <section>
                 <p class="text-sm">{s.payload.extension.description}</p>

--- a/src/pages/developer/[id].astro
+++ b/src/pages/developer/[id].astro
@@ -8,6 +8,7 @@ import { createApiClient, ApiRequestError } from '@/lib/apiClient';
 import { formString } from '@/lib/form';
 import { isSafeHttpUrl } from '@/lib/safe-url';
 import { env } from 'cloudflare:workers';
+import { CircleAlert } from '@lucide/astro';
 
 const { id } = Astro.params;
 
@@ -66,9 +67,15 @@ const extensions = await getExtensionsByDeveloperId(
     <div class="flex-1">
       <div class="flex items-center gap-2 flex-wrap">
         <h1 class="text-2xl font-semibold tracking-tight">{developer.name}</h1>
-        <span class="badge-secondary">{developer.type}</span>
+        <span class="badge" data-variant="secondary">{developer.type}</span>
         {developer.approved && <span class="badge">Approved</span>}
-        {developer.unclaimed && <span class="badge-secondary">Unclaimed</span>}
+        {
+          developer.unclaimed && (
+            <span class="badge" data-variant="secondary">
+              Unclaimed
+            </span>
+          )
+        }
       </div>
       {
         developer.URL && isSafeHttpUrl(developer.URL) ? (
@@ -110,8 +117,9 @@ const extensions = await getExtensionsByDeveloperId(
               every claim before ownership changes.
             </p>
             {claimError && (
-              <div class="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                {claimError}
+              <div class="alert" data-variant="destructive">
+                <CircleAlert class="size-4" />
+                <section>{claimError}</section>
               </div>
             )}
             {currentUser ? (

--- a/src/pages/developer/[id].astro
+++ b/src/pages/developer/[id].astro
@@ -100,59 +100,63 @@ const extensions = await getExtensionsByDeveloperId(
 
   {
     developer.unclaimed && (
-      <div class="card space-y-3 mb-8">
-        <h2 class="font-semibold">
-          This profile hasn't been linked to an account
-        </h2>
-        {claimSubmitted ? (
-          <p class="text-sm text-muted-foreground">
-            Your claim has been submitted for moderator review. You can check
-            its status on your{' '}
-            <a href="/account/developer">developer profile page</a>.
-          </p>
-        ) : (
-          <>
+      <div class="card mb-8">
+        <header>
+          <h2 class="font-semibold">
+            This profile hasn't been linked to an account
+          </h2>
+        </header>
+        <section class="space-y-3">
+          {claimSubmitted ? (
             <p class="text-sm text-muted-foreground">
-              If this is you, you can request to claim it. A moderator reviews
-              every claim before ownership changes.
+              Your claim has been submitted for moderator review. You can check
+              its status on your{' '}
+              <a href="/account/developer">developer profile page</a>.
             </p>
-            {claimError && (
-              <div class="alert" data-variant="destructive">
-                <CircleAlert class="size-4" />
-                <section>{claimError}</section>
-              </div>
-            )}
-            {currentUser ? (
-              <form method="POST" class="space-y-3">
-                <div class="field">
-                  <label for="note">
-                    Note for the moderator reviewing this (optional)
-                  </label>
-                  <input
-                    class="input"
-                    type="text"
-                    id="note"
-                    name="note"
-                    maxlength="500"
-                    placeholder="e.g. I'm the maintainer, see github.com/..."
-                  />
+          ) : (
+            <>
+              <p class="text-sm text-muted-foreground">
+                If this is you, you can request to claim it. A moderator reviews
+                every claim before ownership changes.
+              </p>
+              {claimError && (
+                <div class="alert" data-variant="destructive">
+                  <CircleAlert class="size-4" />
+                  <section>{claimError}</section>
                 </div>
-                <button type="submit" class="btn" data-size="sm">
-                  Claim this profile
-                </button>
-              </form>
-            ) : (
-              <a
-                href={`/auth/login?redirect=${encodeURIComponent(Astro.url.pathname)}`}
-                class="btn"
-                data-size="sm"
-                data-variant="outline"
-              >
-                Sign In to Claim This Profile
-              </a>
-            )}
-          </>
-        )}
+              )}
+              {currentUser ? (
+                <form method="POST" class="space-y-3">
+                  <div class="field">
+                    <label for="note">
+                      Note for the moderator reviewing this (optional)
+                    </label>
+                    <input
+                      class="input"
+                      type="text"
+                      id="note"
+                      name="note"
+                      maxlength="500"
+                      placeholder="e.g. I'm the maintainer, see github.com/..."
+                    />
+                  </div>
+                  <button type="submit" class="btn" data-size="sm">
+                    Claim this profile
+                  </button>
+                </form>
+              ) : (
+                <a
+                  href={`/auth/login?redirect=${encodeURIComponent(Astro.url.pathname)}`}
+                  class="btn"
+                  data-size="sm"
+                  data-variant="outline"
+                >
+                  Sign In to Claim This Profile
+                </a>
+              )}
+            </>
+          )}
+        </section>
       </div>
     )
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub reconnect prompt and shows your latest developer-claim status on the Account page. Standardizes alerts/badges and moves moderation rejections to a reusable dialog for clearer UX.

- **New Features**
  - Account: Show a banner prompting users without GitHub org access to reconnect; “Reconnect GitHub” links to the auth service account page.
  - Account: Display the newest developer profile claim (pending or rejected with review note) when the user doesn’t yet own a profile; use `listMyClaimsSafely` so errors don’t break the page.
  - UI/Moderation/Backend: Standardize alerts and badge variants; extract a reusable `RejectDialog` for rejecting claims/submissions with a required reason; add `hasLinkedGithub(db, userId)`, `listMyClaimsSafely(api)`, and export `ISSUER` for reuse.

<sup>Written for commit 0c2ee2f9c98f66571f82a0a30891c0b86938483c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

