### PR TITLE
Fix GitHub reconnect: stuck banner and wrong redirect destination

### DIFF
--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -58,6 +58,15 @@ const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
   approved: undefined,
   rejected: 'destructive',
 };
+
+// After linking GitHub, send the user back through our own OIDC login
+// (rather than stranding them on auth's own /account page) so the ID token
+// is re-issued with the freshly linked github_login/github_orgs claims and
+// upsertUser refreshes our local copy — otherwise the reconnect banner keeps
+// showing until the next unrelated login.
+const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
+  `${Astro.url.origin}/auth/login?redirect=${encodeURIComponent('/account')}`,
+)}`;
 ---
 
 <Base title="Your Account — FOSSBilling Extensions">
@@ -107,7 +116,7 @@ const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
           </section>
           <footer>
             <a
-              href={`${ISSUER}/account`}
+              href={reconnectUrl}
               class="btn"
               data-size="sm"
               data-variant="outline"


### PR DESCRIPTION
## Summary
- The "Reconnect GitHub" link now passes `callbackURL=<this origin>/auth/login?redirect=/account` to auth's `/account` page (see companion PR https://github.com/FOSSBilling/auth/pull/8).
- After GitHub linking completes, the user is bounced through this site's own `/auth/login` → `/auth/callback`, which re-issues the ID token (now carrying fresh `github_login`/`github_orgs` claims), calls `upsertUser` to refresh the local `users` row, and lands back on `/account`.

## Why
Two related bugs reported after testing in production:
1. Clicking "Grant GitHub org access" didn't resolve the reconnect banner — it only cleared after a full logout/login, because our local copy of `github_login` is only ever refreshed inside `/auth/callback`, and the linking flow never routed back through it.
2. After linking, the user was stranded on `auth.fossbilling.net/account` instead of being sent back here.

Both share the same root cause and the same fix: force the post-link redirect through our own OIDC round-trip instead of straight back to auth's own account page.