### PR TITLE
Fix GitHub reconnect flow and add developer claim cancellation

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -139,6 +139,11 @@ export function createApiClient(env: Cloudflare.Env, sub: string) {
         body: JSON.stringify(note ? { note } : {}),
       }),
 
+    cancelClaim: (id: string) =>
+      call<{ id: string; cancelled: true }>(`/developers/claims/${id}/cancel`, {
+        method: 'POST',
+      }),
+
     listMyClaims: () => call<DeveloperClaim[]>('/developers/claims/mine'),
 
     listPendingClaims: () =>

--- a/src/pages/account/claims/[id]/cancel.ts
+++ b/src/pages/account/claims/[id]/cancel.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import { requireUser } from '@/lib/auth-guard';
+import { createApiClient, ApiRequestError } from '@/lib/apiClient';
+
+export const POST: APIRoute = async (context) => {
+  const guard = await requireUser(context, env);
+  if (guard instanceof Response) return guard;
+  const user = guard;
+
+  const { id } = context.params;
+  if (!id) return context.redirect('/account');
+
+  const api = createApiClient(env, user.sub);
+  try {
+    await api.cancelClaim(id);
+  } catch (e) {
+    const message =
+      e instanceof ApiRequestError ? e.message : 'Unable to cancel claim.';
+    return context.redirect(`/account?error=${encodeURIComponent(message)}`);
+  }
+
+  return context.redirect('/account?claim_cancelled=1');
+};

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -2,11 +2,7 @@
 import Base from '../../../layouts/Base.astro';
 import { env } from 'cloudflare:workers';
 import { requireUser } from '@/lib/auth-guard';
-import {
-  createApiClient,
-  ApiRequestError,
-  listMyClaimsSafely,
-} from '@/lib/apiClient';
+import { createApiClient, ApiRequestError } from '@/lib/apiClient';
 import {
   getDeveloperByOwner,
   getDeveloperById,
@@ -40,7 +36,19 @@ const extensions = isEdit
 
 const api = createApiClient(env, user.sub);
 
-const myClaims: DeveloperClaim[] = isEdit ? [] : await listMyClaimsSafely(api);
+let myClaims: DeveloperClaim[] = [];
+// Unlike the informational display on /account, a failure here must not
+// fail open: this page's own gate below is the actual enforcement point for
+// "only one profile per user", so an unknown claim state has to block
+// creation the same as a known-pending one, not silently allow it.
+let claimsLoadFailed = false;
+if (!isEdit) {
+  try {
+    myClaims = await api.listMyClaims();
+  } catch {
+    claimsLoadFailed = true;
+  }
+}
 // A user can only ever own one developer profile, so a pending claim (which
 // may still be approved and transfer ownership at any time) blocks starting
 // a separate one from scratch — same guard as the "Create" link on /account.
@@ -86,6 +94,8 @@ if (Astro.request.method === 'POST') {
             : 'Unable to delete your developer profile. Please try again.';
       }
     }
+  } else if (!isEdit && claimsLoadFailed) {
+    error = 'Unable to verify your claim status right now. Please try again.';
   } else if (!isEdit && pendingClaim) {
     error =
       'You have a pending claim on another profile — cancel it before creating a new one.';
@@ -135,6 +145,14 @@ const fields = submitted ?? developer;
       can submit extensions under this profile right away. A moderator will
       review it separately and mark it approved, shown as a badge below.
     </p>
+
+    {
+      !isEdit && claimsLoadFailed && (
+        <p class="text-sm text-destructive">
+          Unable to load your profile claims right now.
+        </p>
+      )
+    }
 
     {
       !isEdit && myClaims.length > 0 && (
@@ -243,7 +261,12 @@ const fields = submitted ?? developer;
     }
 
     {
-      !isEdit && pendingClaim ? (
+      !isEdit && claimsLoadFailed ? (
+        <p class="text-muted-foreground text-sm">
+          Unable to verify your claim status right now, so profile creation is
+          paused — please try again.
+        </p>
+      ) : !isEdit && pendingClaim ? (
         <p class="text-muted-foreground text-sm">
           You have a pending claim on{' '}
           <strong>{pendingClaim.developer_id}</strong>. Cancel it above before

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -40,6 +40,12 @@ const extensions = isEdit
 
 const api = createApiClient(env, user.sub);
 
+const myClaims: DeveloperClaim[] = isEdit ? [] : await listMyClaimsSafely(api);
+// A user can only ever own one developer profile, so a pending claim (which
+// may still be approved and transfer ownership at any time) blocks starting
+// a separate one from scratch — same guard as the "Create" link on /account.
+const pendingClaim = myClaims.find((c) => c.status === 'pending');
+
 let error: string | null = Astro.url.searchParams.get('error');
 // Set only when creation failed because the id belongs to an existing,
 // unowned profile (e.g. a legacy extension author) — points the user at
@@ -80,6 +86,9 @@ if (Astro.request.method === 'POST') {
             : 'Unable to delete your developer profile. Please try again.';
       }
     }
+  } else if (!isEdit && pendingClaim) {
+    error =
+      'You have a pending claim on another profile — cancel it before creating a new one.';
   } else {
     try {
       const payload = buildDeveloperProfile(form, developer);
@@ -115,8 +124,6 @@ if (Astro.request.method === 'POST') {
 // Form field values only — isEdit/preview/transfer sections below still key
 // off the real (saved) `developer`, not a failed, unsaved submission.
 const fields = submitted ?? developer;
-
-const myClaims: DeveloperClaim[] = isEdit ? [] : await listMyClaimsSafely(api);
 ---
 
 <Base title="Developer Profile — FOSSBilling Extensions">
@@ -140,19 +147,36 @@ const myClaims: DeveloperClaim[] = isEdit ? [] : await listMyClaimsSafely(api);
               {myClaims.map((c) => (
                 <li class="text-sm flex items-center justify-between gap-3">
                   <code>{c.developer_id}</code>
-                  {c.status === 'pending' && (
-                    <span class="badge" data-variant="secondary">
-                      Pending Review
-                    </span>
-                  )}
-                  {c.status === 'approved' && (
-                    <span class="badge">Approved</span>
-                  )}
-                  {c.status === 'rejected' && (
-                    <span class="badge" data-variant="destructive">
-                      Rejected{c.review_note ? `: ${c.review_note}` : ''}
-                    </span>
-                  )}
+                  <div class="flex items-center gap-2">
+                    {c.status === 'pending' && (
+                      <span class="badge" data-variant="secondary">
+                        Pending Review
+                      </span>
+                    )}
+                    {c.status === 'approved' && (
+                      <span class="badge">Approved</span>
+                    )}
+                    {c.status === 'rejected' && (
+                      <span class="badge" data-variant="destructive">
+                        Rejected{c.review_note ? `: ${c.review_note}` : ''}
+                      </span>
+                    )}
+                    {c.status === 'pending' && (
+                      <form
+                        method="POST"
+                        action={`/account/claims/${c.id}/cancel`}
+                      >
+                        <button
+                          type="submit"
+                          class="btn"
+                          data-size="sm"
+                          data-variant="ghost"
+                        >
+                          Cancel
+                        </button>
+                      </form>
+                    )}
+                  </div>
                 </li>
               ))}
             </ul>
@@ -218,112 +242,125 @@ const myClaims: DeveloperClaim[] = isEdit ? [] : await listMyClaimsSafely(api);
       )
     }
 
-    <form method="POST" class="space-y-8">
-      <fieldset class="fieldset space-y-4">
-        <legend>Publisher Identity</legend>
-        <div class="field">
-          <label for="id">Publisher ID</label>
-          <input
-            class="input"
-            type="text"
-            id="id"
-            name="id"
-            required
-            pattern="[a-z0-9]+(-[a-z0-9]+)*"
-            placeholder="my-org"
-            value={fields?.id}
-            readonly={isEdit}
-          />
-          {
-            isEdit ? (
-              <p>The ID can't be changed after it's created.</p>
-            ) : (
-              <p>
-                Typically your GitHub organization or username — this is used to
-                verify ownership if you (or someone else) later try to claim
-                this profile.
-              </p>
-            )
-          }
-        </div>
-        <div class="field">
-          <label for="name">Publisher Name</label>
-          <input
-            class="input"
-            type="text"
-            id="name"
-            name="name"
-            required
-            value={fields?.name}
-          />
-        </div>
-        <div class="field">
-          <label for="type">Publisher Type</label>
-          <select class="select" id="type" name="type">
-            {
-              DEVELOPER_TYPES.map((t) => (
-                <option value={t} selected={fields?.type === t}>
-                  {t}
-                </option>
-              ))
-            }
-          </select>
-        </div>
-        <div class="field">
-          <label for="url">Publisher URL (Optional)</label>
-          <input
-            class="input"
-            type="url"
-            id="url"
-            name="url"
-            value={fields?.URL}
-          />
-        </div>
-      </fieldset>
-
-      <fieldset class="fieldset space-y-4">
-        <legend>Public Profile</legend>
-        <p>
-          Shown on your public developer page at
-          {developer ? ` /developer/${developer.id}` : ' /developer/<your-id>'}.
+    {
+      !isEdit && pendingClaim ? (
+        <p class="text-muted-foreground text-sm">
+          You have a pending claim on{' '}
+          <strong>{pendingClaim.developer_id}</strong>. Cancel it above before
+          creating a separate profile — a claim can be approved at any time, and
+          you can only ever own one.
         </p>
-        <div class="field">
-          <label for="avatar_url">Avatar/Logo URL (Optional)</label>
-          <input
-            class="input"
-            type="url"
-            id="avatar_url"
-            name="avatar_url"
-            value={fields?.avatar_url}
-          />
-        </div>
-      </fieldset>
+      ) : (
+        <form method="POST" class="space-y-8">
+          <fieldset class="fieldset space-y-4">
+            <legend>Publisher Identity</legend>
+            <div class="field">
+              <label for="id">Publisher ID</label>
+              <input
+                class="input"
+                type="text"
+                id="id"
+                name="id"
+                required
+                pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                placeholder="my-org"
+                value={fields?.id}
+                readonly={isEdit}
+              />
+              {isEdit ? (
+                <p>The ID can't be changed after it's created.</p>
+              ) : (
+                <p>
+                  Typically your GitHub organization or username — this is used
+                  to verify ownership if you (or someone else) later try to
+                  claim this profile.
+                </p>
+              )}
+            </div>
+            <div class="field">
+              <label for="name">Publisher Name</label>
+              <input
+                class="input"
+                type="text"
+                id="name"
+                name="name"
+                required
+                value={fields?.name}
+              />
+            </div>
+            <div class="field">
+              <label for="type">Publisher Type</label>
+              <select class="select" id="type" name="type">
+                {DEVELOPER_TYPES.map((t) => (
+                  <option value={t} selected={fields?.type === t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div class="field">
+              <label for="url">Publisher URL (Optional)</label>
+              <input
+                class="input"
+                type="url"
+                id="url"
+                name="url"
+                value={fields?.URL}
+              />
+            </div>
+          </fieldset>
 
-      <fieldset class="fieldset space-y-4">
-        <legend>Private contact</legend>
-        <div class="field">
-          <label for="contact_email">Contact Email (Optional)</label>
-          <input
-            class="input"
-            type="email"
-            id="contact_email"
-            name="contact_email"
-            value={fields?.contact_email}
-          />
-          <p>
-            Never shown publicly — only visible to FOSSBilling moderators, in
-            case they need to reach you about this profile or its extensions.
-          </p>
-        </div>
-      </fieldset>
+          <fieldset class="fieldset space-y-4">
+            <legend>Public Profile</legend>
+            <p>
+              Shown on your public developer page at
+              {developer
+                ? ` /developer/${developer.id}`
+                : ' /developer/<your-id>'}
+              .
+            </p>
+            <div class="field">
+              <label for="avatar_url">Avatar/Logo URL (Optional)</label>
+              <input
+                class="input"
+                type="url"
+                id="avatar_url"
+                name="avatar_url"
+                value={fields?.avatar_url}
+              />
+            </div>
+          </fieldset>
 
-      <div class="flex justify-end gap-3">
-        <a href="/account" class="btn" data-variant="ghost">Cancel</a>
-        <button type="submit" class="btn">
-          {isEdit ? 'Save Changes' : 'Create Developer Profile'}
-        </button>
-      </div>
-    </form>
+          <fieldset class="fieldset space-y-4">
+            <legend>Private contact</legend>
+            <div class="field">
+              <label for="contact_email">Contact Email (Optional)</label>
+              <input
+                class="input"
+                type="email"
+                id="contact_email"
+                name="contact_email"
+                value={fields?.contact_email}
+              />
+              <p>
+                Never shown publicly — only visible to FOSSBilling moderators,
+                in case they need to reach you about this profile or its
+                extensions.
+              </p>
+            </div>
+          </fieldset>
+
+          <div class="flex justify-end gap-3">
+            <a href="/account" class="btn" data-variant="ghost">
+              Cancel
+            </a>
+            <button type="submit" class="btn">
+              {isEdit ? 'Save Changes' : 'Create Developer Profile'}
+            </button>
+          </div>
+        </form>
+      )
+    }
 
     {
       isEdit && (

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -61,6 +61,11 @@ const latestClaim = myClaims[0];
 // a separate one from scratch — checked across all claims, not just
 // latestClaim, since claim() doesn't prevent pending claims on multiple ids.
 const pendingClaim = myClaims.find((c) => c.status === 'pending');
+// Prefer showing the pending claim over a newer non-pending one — otherwise
+// an older pending claim (Create hidden because of it) could have no
+// visible cancel action if a newer claim on a different id was rejected
+// since, leaving the page with no way to proceed.
+const displayClaim = pendingClaim ?? latestClaim;
 
 const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
   pending: 'secondary',
@@ -186,25 +191,25 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
                 </span>
               )}
             </p>
-          ) : latestClaim ? (
+          ) : displayClaim ? (
             <div class="space-y-2">
               <p class="text-sm flex items-center gap-2">
-                Claim on <strong>{latestClaim.developer_id}</strong>
-                {latestClaim.status === 'pending' && (
+                Claim on <strong>{displayClaim.developer_id}</strong>
+                {displayClaim.status === 'pending' && (
                   <span class="badge" data-variant="secondary">
                     Pending Review
                   </span>
                 )}
-                {latestClaim.status === 'rejected' && (
+                {displayClaim.status === 'rejected' && (
                   <span class="badge" data-variant="destructive">
                     Rejected
-                    {latestClaim.review_note
-                      ? `: ${latestClaim.review_note}`
+                    {displayClaim.review_note
+                      ? `: ${displayClaim.review_note}`
                       : ''}
                   </span>
                 )}
               </p>
-              {latestClaim.status === 'pending' && (
+              {displayClaim.status === 'pending' && (
                 <div class="flex items-center gap-2">
                   <p class="text-muted-foreground text-sm">
                     You can't create a separate profile while this claim is
@@ -212,7 +217,7 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
                   </p>
                   <form
                     method="POST"
-                    action={`/account/claims/${latestClaim.id}/cancel`}
+                    action={`/account/claims/${displayClaim.id}/cancel`}
                   >
                     <button
                       type="submit"

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -8,7 +8,7 @@ import { isModerator, hasLinkedGithub } from '@/lib/users';
 import { ISSUER } from '@/lib/oauth';
 import { getLatestRelease } from '@/types';
 import type { DeveloperClaim, Submission } from '@/types';
-import { CircleCheck } from '@lucide/astro';
+import { CircleAlert, CircleCheck } from '@lucide/astro';
 
 const guard = await requireUser(Astro, env);
 if (guard instanceof Response) return guard;
@@ -28,13 +28,17 @@ const banner: Record<string, string> = {
   profile_saved: 'Developer Profile Saved.',
   profile_updated: 'Profile Updated.',
   profile_deleted: 'Developer Profile Deleted.',
+  claim_cancelled: 'Claim Cancelled.',
 };
 const bannerKey = [
   'submitted',
   'profile_saved',
   'profile_updated',
   'profile_deleted',
+  'claim_cancelled',
 ].find((key) => Astro.url.searchParams.has(key));
+
+const error = Astro.url.searchParams.get('error');
 
 const api = createApiClient(env, user.sub);
 let submissions: Submission[] = [];
@@ -52,6 +56,11 @@ const myClaims: DeveloperClaim[] = developer
 // immediately (developer becomes truthy), so only pending/rejected ever
 // surface here.
 const latestClaim = myClaims[0];
+// A user can only ever own one developer profile, so a pending claim (which
+// may still be approved and transfer ownership at any time) blocks starting
+// a separate one from scratch — checked across all claims, not just
+// latestClaim, since claim() doesn't prevent pending claims on multiple ids.
+const pendingClaim = myClaims.find((c) => c.status === 'pending');
 
 const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
   pending: 'secondary',
@@ -107,6 +116,15 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
     }
 
     {
+      error && (
+        <div class="alert" data-variant="destructive">
+          <CircleAlert class="size-4" />
+          <section>{error}</section>
+        </div>
+      )
+    }
+
+    {
       !githubLinked && (
         <div class="alert">
           <h2>Reconnect GitHub</h2>
@@ -131,14 +149,29 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
     <section class="card">
       <header class="flex items-center justify-between">
         <h2 class="font-semibold">Developer Profile</h2>
-        <a
-          href="/account/developer"
-          class="btn"
-          data-size="sm"
-          data-variant="outline"
-        >
-          {developer ? 'Edit' : 'Create'}
-        </a>
+        {
+          developer ? (
+            <a
+              href="/account/developer"
+              class="btn"
+              data-size="sm"
+              data-variant="outline"
+            >
+              Edit
+            </a>
+          ) : (
+            !pendingClaim && (
+              <a
+                href="/account/developer"
+                class="btn"
+                data-size="sm"
+                data-variant="outline"
+              >
+                Create
+              </a>
+            )
+          )
+        }
       </header>
       <section>
         {
@@ -154,22 +187,45 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
               )}
             </p>
           ) : latestClaim ? (
-            <p class="text-sm flex items-center gap-2">
-              Claim on <strong>{latestClaim.developer_id}</strong>
+            <div class="space-y-2">
+              <p class="text-sm flex items-center gap-2">
+                Claim on <strong>{latestClaim.developer_id}</strong>
+                {latestClaim.status === 'pending' && (
+                  <span class="badge" data-variant="secondary">
+                    Pending Review
+                  </span>
+                )}
+                {latestClaim.status === 'rejected' && (
+                  <span class="badge" data-variant="destructive">
+                    Rejected
+                    {latestClaim.review_note
+                      ? `: ${latestClaim.review_note}`
+                      : ''}
+                  </span>
+                )}
+              </p>
               {latestClaim.status === 'pending' && (
-                <span class="badge" data-variant="secondary">
-                  Pending Review
-                </span>
+                <div class="flex items-center gap-2">
+                  <p class="text-muted-foreground text-sm">
+                    You can't create a separate profile while this claim is
+                    pending.
+                  </p>
+                  <form
+                    method="POST"
+                    action={`/account/claims/${latestClaim.id}/cancel`}
+                  >
+                    <button
+                      type="submit"
+                      class="btn"
+                      data-size="sm"
+                      data-variant="ghost"
+                    >
+                      Cancel Claim
+                    </button>
+                  </form>
+                </div>
               )}
-              {latestClaim.status === 'rejected' && (
-                <span class="badge" data-variant="destructive">
-                  Rejected
-                  {latestClaim.review_note
-                    ? `: ${latestClaim.review_note}`
-                    : ''}
-                </span>
-              )}
-            </p>
+            </div>
           ) : (
             <p class="text-muted-foreground text-sm">
               You don't have a developer profile yet — create one before

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -58,6 +58,15 @@ const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
   approved: undefined,
   rejected: 'destructive',
 };
+
+// After linking GitHub, send the user back through our own OIDC login
+// (rather than stranding them on auth's own /account page) so the ID token
+// is re-issued with the freshly linked github_login/github_orgs claims and
+// upsertUser refreshes our local copy — otherwise the reconnect banner keeps
+// showing until the next unrelated login.
+const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
+  `${Astro.url.origin}/auth/login?redirect=${encodeURIComponent('/account')}`,
+)}`;
 ---
 
 <Base title="Your Account — FOSSBilling Extensions">
@@ -107,7 +116,7 @@ const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
           </section>
           <footer>
             <a
-              href={`${ISSUER}/account`}
+              href={reconnectUrl}
               class="btn"
               data-size="sm"
               data-variant="outline"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the GitHub reconnect flow so users return to /account with refreshed claims, and adds a way to cancel pending developer claims to unblock users. Also closes edge cases so the cancel action and creation gate stay in sync.

- **New Features**
  - Add claim cancellation via `POST /account/claims/:id/cancel` calling backend `POST /developers/claims/:id/cancel`.
  - Show a Cancel button for pending claims on account and developer pages; display a success banner and error alerts.
  - Block creating a new developer profile while any claim is pending, with clear messaging.

- **Bug Fixes**
  - Route "Reconnect GitHub" through our own login using `ISSUER/account?callbackURL=...` so users land back on `/account`, and refresh the ID token after linking to update `github_login/github_orgs` and remove the stale reconnect banner.
  - Ensure the pending claim (if any) is always the one shown with a Cancel action on `/account`, and treat claim-load failures on `/account/developer` as blocking creation to prevent duplicate profiles.

<sup>Written for commit 622616d395660e05e2c48c9550ca8c4b591b59b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

