### PR TITLE
Display developer names and add GitHub re-verification UI

### DIFF
--- a/src/components/GithubVerifiedBadge.astro
+++ b/src/components/GithubVerifiedBadge.astro
@@ -1,0 +1,38 @@
+---
+interface Props {
+  verified: boolean | undefined;
+  verifiedAt: string | null | undefined;
+}
+
+const { verified, verifiedAt } = Astro.props;
+---
+
+{
+  verified === true && (
+    <span
+      class="badge"
+      title={
+        verifiedAt
+          ? `Verified ${new Date(verifiedAt).toLocaleString()}`
+          : undefined
+      }
+    >
+      GitHub verified
+    </span>
+  )
+}
+{
+  verified === false && (
+    <span
+      class="badge"
+      data-variant="destructive"
+      title={
+        verifiedAt
+          ? `Last checked ${new Date(verifiedAt).toLocaleString()}`
+          : undefined
+      }
+    >
+      Not GitHub verified
+    </span>
+  )
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -98,6 +98,15 @@ export function createApiClient(env: Cloudflare.Env, sub: string) {
         method: 'DELETE',
       }),
 
+    // Re-checks the caller's own developer profile against their current
+    // linked GitHub identity — no GitHub API call on the api repo's side,
+    // just a fresh comparison against already-synced data. Used both by the
+    // owner's own "Re-verify" action and opportunistically after login.
+    reverifyDeveloper: () =>
+      call<DeveloperProfile>('/developers/me/reverify', {
+        method: 'POST',
+      }),
+
     listUnapprovedDevelopers: () =>
       call<DeveloperProfile[]>('/developers/unapproved'),
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -76,7 +76,9 @@ function parseDeveloperProfileRow(row: DeveloperProfileRow): DeveloperProfile {
     content_revision: row.content_revision ?? 1,
     unclaimed: row.unclaimed === 1,
     github_org_verified:
-      row.github_org_verified == null ? undefined : row.github_org_verified === 1,
+      row.github_org_verified == null
+        ? undefined
+        : row.github_org_verified === 1,
     github_verification_note: row.github_verification_note ?? undefined,
     github_verified_at: row.github_verified_at ?? undefined,
   } as DeveloperProfile;

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -57,6 +57,11 @@ type DeveloperProfileRow = {
   // Not selected by SELECT_DEVELOPER_PUBLIC — getDeveloperById's return type
   // omits content_revision, so the fallback below is never exposed there.
   content_revision?: number;
+  // Only selected by getDeveloperByOwner (the owner's own read) — never
+  // public, same trust level as contact_email above.
+  github_org_verified?: number | null;
+  github_verification_note?: string | null;
+  github_verified_at?: string | null;
 };
 
 function parseDeveloperProfileRow(row: DeveloperProfileRow): DeveloperProfile {
@@ -70,6 +75,10 @@ function parseDeveloperProfileRow(row: DeveloperProfileRow): DeveloperProfile {
     approved: row.approved_at !== null,
     content_revision: row.content_revision ?? 1,
     unclaimed: row.unclaimed === 1,
+    github_org_verified:
+      row.github_org_verified == null ? undefined : row.github_org_verified === 1,
+    github_verification_note: row.github_verification_note ?? undefined,
+    github_verified_at: row.github_verified_at ?? undefined,
   } as DeveloperProfile;
 }
 
@@ -142,7 +151,7 @@ export async function getDeveloperByOwner(
   try {
     row = await db
       .prepare(
-        'SELECT id, type, name, url, avatar_url, contact_email, approved_at, content_revision FROM developers WHERE owner_user_id = ?',
+        'SELECT id, type, name, url, avatar_url, contact_email, approved_at, content_revision, github_org_verified, github_verification_note, github_verified_at FROM developers WHERE owner_user_id = ?',
       )
       .bind(userId)
       .first<DeveloperProfileRow>();

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -57,20 +57,26 @@ export async function isModerator(
   return row?.is_moderator === 1;
 }
 
-// True once a user has signed in via GitHub since the auth service started
-// requesting read:org (see oauth.ts's UserInfo type) — used to prompt
-// existing accounts that signed in before that change to reconnect, since
-// their developer-profile claims otherwise fall back to unverified/manual
-// review indefinitely.
+// True once a user's GitHub org memberships have actually been fetched —
+// checked via github_orgs, NOT github_login. github_login is set on every
+// GitHub sign-in unconditionally, but github_orgs is only written when the
+// read:org-scoped org-membership fetch succeeds (see the auth repo's
+// persistGithubProfile/fetchActiveOrgLogins) — it stays null if that scope
+// was never granted or the fetch failed, which can happen even though
+// github_login is already set. Checking github_login here would mark those
+// accounts as "linked" and permanently hide the reconnect prompt, leaving
+// their developer-profile claims stuck on unverified/manual review with no
+// visible way to fix it. An empty (but non-null) github_orgs is a
+// legitimate "confirmed zero memberships" and correctly counts as linked.
 export async function hasLinkedGithub(
   db: D1Database,
   userId: string,
 ): Promise<boolean> {
   const row = await db
-    .prepare('SELECT github_login FROM users WHERE id = ?')
+    .prepare('SELECT github_orgs FROM users WHERE id = ?')
     .bind(userId)
-    .first<{ github_login: string | null }>();
-  return Boolean(row?.github_login);
+    .first<{ github_orgs: string | null }>();
+  return row?.github_orgs != null;
 }
 
 export async function deleteUser(

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -13,7 +13,7 @@ import {
   DeveloperValidationError,
 } from '@/lib/developer-form';
 import { DEVELOPER_TYPES } from '@/types';
-import { CircleAlert } from '@lucide/astro';
+import { CircleAlert, CircleCheck } from '@lucide/astro';
 import type {
   DeveloperClaim,
   DeveloperProfileInput,
@@ -79,6 +79,16 @@ if (Astro.request.method === 'POST') {
         e instanceof ApiRequestError
           ? e.message
           : 'Unable to create a transfer link. Please try again.';
+    }
+  } else if (form.get('intent') === 'reverify' && developer) {
+    try {
+      developer = await api.reverifyDeveloper();
+      return Astro.redirect('/account/developer?reverified=1');
+    } catch (e) {
+      error =
+        e instanceof ApiRequestError
+          ? e.message
+          : 'Unable to re-verify your GitHub identity right now. Please try again.';
     }
   } else if (form.get('intent') === 'delete' && developer) {
     // extensions.length > 0 falls through here as a no-op — the danger-zone
@@ -205,7 +215,12 @@ const fields = submitted ?? developer;
 
     {
       isEdit && (
-        <div class="card">
+        // overflow-visible: basecoat's .card sets overflow-hidden (to clip
+        // a first/last-child image to its rounded corners, not relevant
+        // here) which otherwise clips the Re-verify button's tooltip —
+        // Tailwind's utilities layer overrides basecoat's components layer
+        // regardless of source order, so this wins cleanly without !important.
+        <div class="card overflow-visible">
           <section class="flex items-center gap-4">
             {developer!.avatar_url && (
               <img
@@ -224,6 +239,31 @@ const fields = submitted ?? developer;
                     Not Yet Reviewed
                   </span>
                 )}
+                {developer!.github_org_verified === true && (
+                  <span
+                    class="badge"
+                    title={
+                      developer!.github_verified_at
+                        ? `Verified ${new Date(developer!.github_verified_at).toLocaleString()}`
+                        : undefined
+                    }
+                  >
+                    GitHub verified
+                  </span>
+                )}
+                {developer!.github_org_verified === false && (
+                  <span
+                    class="badge"
+                    data-variant="destructive"
+                    title={
+                      developer!.github_verified_at
+                        ? `Last checked ${new Date(developer!.github_verified_at).toLocaleString()}`
+                        : undefined
+                    }
+                  >
+                    Not GitHub verified
+                  </span>
+                )}
               </p>
             </div>
             <a
@@ -234,6 +274,48 @@ const fields = submitted ?? developer;
             >
               View Public Profile
             </a>
+            <form method="POST">
+              <input type="hidden" name="intent" value="reverify" />
+              <button
+                type="submit"
+                class="btn"
+                data-size="sm"
+                data-variant={developer!.github_org_verified === false
+                  ? 'primary'
+                  : 'ghost'}
+                data-tooltip="Check GitHub verification now"
+                data-side="bottom"
+              >
+                Re-verify
+              </button>
+            </form>
+          </section>
+          {
+            developer!.github_org_verified === false && (
+              <div class="alert mt-4" data-variant="destructive">
+                <CircleAlert class="size-4" />
+                <section>
+                  Your linked GitHub identity no longer matches this profile.
+                  This doesn't affect your submissions or ownership — it's
+                  only shown to moderators as a trust signal. Re-verify if
+                  this should still match (e.g. you rejoined the
+                  organization).
+                </section>
+              </div>
+            )
+          }
+        </div>
+      )
+    }
+
+    {
+      Astro.url.searchParams.get('reverified') && (
+        <div class="alert">
+          <CircleCheck class="size-4" />
+          <section>
+            {developer?.github_org_verified
+              ? 'GitHub verification re-checked — your linked GitHub identity matches this profile.'
+              : "GitHub verification re-checked — your linked GitHub identity doesn't currently match this profile."}
           </section>
         </div>
       )

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -280,9 +280,9 @@ const fields = submitted ?? developer;
                 type="submit"
                 class="btn"
                 data-size="sm"
-                data-variant={developer!.github_org_verified === false
-                  ? 'primary'
-                  : 'ghost'}
+                data-variant={
+                  developer!.github_org_verified === false ? 'primary' : 'ghost'
+                }
                 data-tooltip="Check GitHub verification now"
                 data-side="bottom"
               >
@@ -290,20 +290,17 @@ const fields = submitted ?? developer;
               </button>
             </form>
           </section>
-          {
-            developer!.github_org_verified === false && (
-              <div class="alert mt-4" data-variant="destructive">
-                <CircleAlert class="size-4" />
-                <section>
-                  Your linked GitHub identity no longer matches this profile.
-                  This doesn't affect your submissions or ownership — it's
-                  only shown to moderators as a trust signal. Re-verify if
-                  this should still match (e.g. you rejoined the
-                  organization).
-                </section>
-              </div>
-            )
-          }
+          {developer!.github_org_verified === false && (
+            <div class="alert mt-4" data-variant="destructive">
+              <CircleAlert class="size-4" />
+              <section>
+                Your linked GitHub identity no longer matches this profile. This
+                doesn't affect your submissions or ownership — it's only shown
+                to moderators as a trust signal. Re-verify if this should still
+                match (e.g. you rejoined the organization).
+              </section>
+            </div>
+          )}
         </div>
       )
     }

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -14,6 +14,7 @@ import {
 } from '@/lib/developer-form';
 import { DEVELOPER_TYPES } from '@/types';
 import { CircleAlert, CircleCheck } from '@lucide/astro';
+import GithubVerifiedBadge from '@/components/GithubVerifiedBadge.astro';
 import type {
   DeveloperClaim,
   DeveloperProfileInput,
@@ -239,31 +240,10 @@ const fields = submitted ?? developer;
                     Not Yet Reviewed
                   </span>
                 )}
-                {developer!.github_org_verified === true && (
-                  <span
-                    class="badge"
-                    title={
-                      developer!.github_verified_at
-                        ? `Verified ${new Date(developer!.github_verified_at).toLocaleString()}`
-                        : undefined
-                    }
-                  >
-                    GitHub verified
-                  </span>
-                )}
-                {developer!.github_org_verified === false && (
-                  <span
-                    class="badge"
-                    data-variant="destructive"
-                    title={
-                      developer!.github_verified_at
-                        ? `Last checked ${new Date(developer!.github_verified_at).toLocaleString()}`
-                        : undefined
-                    }
-                  >
-                    Not GitHub verified
-                  </span>
-                )}
+                <GithubVerifiedBadge
+                  verified={developer!.github_org_verified}
+                  verifiedAt={developer!.github_verified_at}
+                />
               </p>
             </div>
             <a

--- a/src/pages/account/moderate/developers/[id]/history.astro
+++ b/src/pages/account/moderate/developers/[id]/history.astro
@@ -91,7 +91,8 @@ try {
                   )}
                 </p>
                 <p class="text-sm text-muted-foreground mt-1">
-                  Changed by <code>{entry.changed_by}</code>
+                  Changed by{' '}
+                  <strong>{entry.changed_by_name ?? entry.changed_by}</strong>
                 </p>
               </section>
             </li>

--- a/src/pages/account/moderate/developers/claims/index.astro
+++ b/src/pages/account/moderate/developers/claims/index.astro
@@ -71,8 +71,18 @@ try {
                 </h2>
                 <p class="text-sm text-muted-foreground">
                   {c.developer_type} &middot; claimed by{' '}
-                  <code>{c.claimant_id}</code> on{' '}
-                  {new Date(c.created_at).toLocaleDateString()}
+                  <strong>{c.claimant_name ?? c.claimant_id}</strong>
+                  {c.claimant_github_login && (
+                    <>
+                      {' '}
+                      (<a
+                        href={`https://github.com/${c.claimant_github_login}`}
+                      >
+                        @{c.claimant_github_login}
+                      </a>)
+                    </>
+                  )}{' '}
+                  on {new Date(c.created_at).toLocaleDateString()}
                 </p>
                 {c.note && <p class="text-sm mt-1">&ldquo;{c.note}&rdquo;</p>}
               </header>

--- a/src/pages/account/moderate/developers/claims/index.astro
+++ b/src/pages/account/moderate/developers/claims/index.astro
@@ -75,11 +75,11 @@ try {
                   {c.claimant_github_login && (
                     <>
                       {' '}
-                      (<a
-                        href={`https://github.com/${c.claimant_github_login}`}
-                      >
+                      (
+                      <a href={`https://github.com/${c.claimant_github_login}`}>
                         @{c.claimant_github_login}
-                      </a>)
+                      </a>
+                      )
                     </>
                   )}{' '}
                   on {new Date(c.created_at).toLocaleDateString()}

--- a/src/pages/account/moderate/developers/index.astro
+++ b/src/pages/account/moderate/developers/index.astro
@@ -101,8 +101,35 @@ try {
                   <h2 class="font-semibold flex items-center gap-2">
                     {d.name} ({d.id})
                     {d.approved && <span class="badge">Approved</span>}
-                    {d.github_org_verified && (
-                      <span class="badge">GitHub verified</span>
+                    {d.github_org_verified === true && (
+                      <span
+                        class="badge"
+                        title={
+                          d.github_verified_at
+                            ? `Verified ${new Date(d.github_verified_at).toLocaleString()}`
+                            : undefined
+                        }
+                      >
+                        GitHub verified
+                      </span>
+                    )}
+                    {d.github_org_verified === false && (
+                      <span
+                        class="badge"
+                        data-variant="destructive"
+                        title={
+                          d.github_verified_at
+                            ? `Last checked ${new Date(d.github_verified_at).toLocaleString()}`
+                            : undefined
+                        }
+                      >
+                        Not GitHub verified
+                      </span>
+                    )}
+                    {d.unclaimed && (
+                      <span class="badge" data-variant="secondary">
+                        Unclaimed
+                      </span>
                     )}
                   </h2>
                   <p class="text-sm text-muted-foreground">
@@ -119,6 +146,21 @@ try {
                       </>
                     )}
                   </p>
+                  {d.owner_name && (
+                    <p class="text-sm text-muted-foreground">
+                      Owned by <strong>{d.owner_name}</strong>
+                      {d.owner_github_login && (
+                        <>
+                          {' '}
+                          (<a
+                            href={`https://github.com/${d.owner_github_login}`}
+                          >
+                            @{d.owner_github_login}
+                          </a>)
+                        </>
+                      )}
+                    </p>
+                  )}
                 </div>
                 <div class="flex items-center gap-2">
                   <a

--- a/src/pages/account/moderate/developers/index.astro
+++ b/src/pages/account/moderate/developers/index.astro
@@ -6,6 +6,7 @@ import { createApiClient } from '@/lib/apiClient';
 import { isSafeHttpUrl } from '@/lib/safe-url';
 import type { DeveloperProfile } from '@/types';
 import { CircleAlert } from '@lucide/astro';
+import GithubVerifiedBadge from '@/components/GithubVerifiedBadge.astro';
 
 const guard = await requireModerator(Astro, env);
 if (guard instanceof Response) return guard;
@@ -101,31 +102,10 @@ try {
                   <h2 class="font-semibold flex items-center gap-2">
                     {d.name} ({d.id})
                     {d.approved && <span class="badge">Approved</span>}
-                    {d.github_org_verified === true && (
-                      <span
-                        class="badge"
-                        title={
-                          d.github_verified_at
-                            ? `Verified ${new Date(d.github_verified_at).toLocaleString()}`
-                            : undefined
-                        }
-                      >
-                        GitHub verified
-                      </span>
-                    )}
-                    {d.github_org_verified === false && (
-                      <span
-                        class="badge"
-                        data-variant="destructive"
-                        title={
-                          d.github_verified_at
-                            ? `Last checked ${new Date(d.github_verified_at).toLocaleString()}`
-                            : undefined
-                        }
-                      >
-                        Not GitHub verified
-                      </span>
-                    )}
+                    <GithubVerifiedBadge
+                      verified={d.github_org_verified}
+                      verifiedAt={d.github_verified_at}
+                    />
                     {d.unclaimed && (
                       <span class="badge" data-variant="secondary">
                         Unclaimed

--- a/src/pages/account/moderate/developers/index.astro
+++ b/src/pages/account/moderate/developers/index.astro
@@ -152,11 +152,13 @@ try {
                       {d.owner_github_login && (
                         <>
                           {' '}
-                          (<a
+                          (
+                          <a
                             href={`https://github.com/${d.owner_github_login}`}
                           >
                             @{d.owner_github_login}
-                          </a>)
+                          </a>
+                          )
                         </>
                       )}
                     </p>

--- a/src/pages/auth/callback.ts
+++ b/src/pages/auth/callback.ts
@@ -14,6 +14,8 @@ import {
   SESSION_MAX_AGE,
 } from '@/lib/session';
 import { upsertUser } from '@/lib/users';
+import { getDeveloperByOwner } from '@/lib/database';
+import { createApiClient } from '@/lib/apiClient';
 
 export const GET: APIRoute = async ({ cookies, redirect, url }) => {
   const verifier = cookies.get(OAUTH_VERIFIER_COOKIE)?.value;
@@ -60,6 +62,21 @@ export const GET: APIRoute = async ({ cookies, redirect, url }) => {
   // doesn't depend on it, only future ownership features will.
   try {
     await upsertUser(env.DB_EXTENSIONS, userInfo);
+  } catch {}
+
+  // Opportunistic re-verification: if this account owns a developer
+  // profile, every login is a chance to notice their linked GitHub
+  // identity (just refreshed above) no longer matches — or now does,
+  // if it didn't before. Best-effort, same as upsertUser above; a
+  // failure here must never block signing in.
+  try {
+    const developer = await getDeveloperByOwner(
+      env.DB_EXTENSIONS,
+      userInfo.sub,
+    );
+    if (developer) {
+      await createApiClient(env, userInfo.sub).reverifyDeveloper();
+    }
   } catch {}
 
   const secure = url.protocol === 'https:';

--- a/src/pages/auth/callback.ts
+++ b/src/pages/auth/callback.ts
@@ -68,13 +68,19 @@ export const GET: APIRoute = async ({ cookies, redirect, url }) => {
   // profile, every login is a chance to notice their linked GitHub
   // identity (just refreshed above) no longer matches — or now does,
   // if it didn't before. Best-effort, same as upsertUser above; a
-  // failure here must never block signing in.
+  // failure here must never block signing in. Skipped when already
+  // checked recently so a user logging in repeatedly doesn't add an
+  // extra API round-trip to every one of those logins.
+  const RECENT_VERIFICATION_MS = 60 * 60 * 1000;
   try {
     const developer = await getDeveloperByOwner(
       env.DB_EXTENSIONS,
       userInfo.sub,
     );
-    if (developer) {
+    const lastVerifiedAt = developer?.github_verified_at
+      ? new Date(developer.github_verified_at).getTime()
+      : 0;
+    if (developer && Date.now() - lastVerifiedAt > RECENT_VERIFICATION_MS) {
       await createApiClient(env, userInfo.sub).reverifyDeveloper();
     }
   } catch {}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,6 +154,7 @@ export type DeveloperProfileInput = Omit<
   | 'content_revision'
   | 'github_org_verified'
   | 'github_verification_note'
+  | 'github_verified_at'
 >;
 
 // What getDeveloperById (the public /developer/[id] read) returns —
@@ -167,6 +168,9 @@ export type PublicDeveloperProfile = Omit<
   | 'content_revision'
   | 'github_org_verified'
   | 'github_verification_note'
+  | 'github_verified_at'
+  | 'owner_name'
+  | 'owner_github_login'
 >;
 
 // A snapshot of a developers row as it existed right after one

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,19 +117,32 @@ export type DeveloperProfile = Developer & {
   // POST /developers/{id}/approve as `expected_revision` so an approval
   // can't silently apply to a profile edited after it was reviewed.
   content_revision: number;
-  // Local-only: derived from `owner_user_id IS NULL` by getDeveloperById's
-  // own query, not part of the api repo's DeveloperProfile response. Never
-  // set on profiles read via the api client (upsertDeveloperProfile,
-  // listUnapprovedDevelopers, listAllDevelopers) — only on the public
-  // /developer/[id] read.
+  // For the public /developer/[id] read, derived locally from
+  // `owner_user_id IS NULL` by getDeveloperById's own query. For the
+  // moderator queue (listUnapprovedDevelopers/listAllDevelopers), set by
+  // the api repo's listAll/listUnapproved instead (same meaning — don't
+  // infer this from owner_name being present, since a real owner can still
+  // have a null name). Absent on every other DeveloperProfile response.
   unclaimed?: boolean;
-  // Server-computed at creation time only (api repo's
-  // DevelopersDatabase.verifyGithubOwnership()) — whether this id was
-  // confirmed to match the creator's own linked GitHub org/username.
-  // Moderator-review signal, not selected by the public /developer/[id]
-  // query (SELECT_DEVELOPER_PUBLIC in database.ts).
+  // Server-computed — see the api repo's DevelopersDatabase.
+  // verifyGithubOwnership() (at claim/creation time) and reverifyOwn()
+  // (opportunistic re-check on login, or the owner's own "Re-verify"
+  // action) — whether this id currently matches the owner's linked GitHub
+  // org/username. Moderator/owner-review signal, not selected by the
+  // public /developer/[id] query (SELECT_DEVELOPER_PUBLIC in database.ts).
   github_org_verified?: boolean;
   github_verification_note?: string;
+  // Set whenever github_org_verified was last (re-)computed to a
+  // definitive true/false. Absent/stale on an inconclusive check.
+  github_verified_at?: string;
+  // Only populated by listUnapprovedDevelopers/listAllDevelopers (the
+  // moderator queue) — the api repo's listAll/listUnapproved join for it.
+  // Null when the profile has no owner, or the owner has no name on file.
+  // Absent on every other DeveloperProfile response. Never present on the
+  // public /developer/[id] read — owner identity is intentionally never
+  // exposed publicly.
+  owner_name?: string | null;
+  owner_github_login?: string | null;
 };
 
 // Body for PUT /extensions/v2/developers/me — everything but the server-set
@@ -166,6 +179,9 @@ export type DeveloperHistoryEntry = {
   name: string;
   URL?: string;
   changed_by: string;
+  // The editor's account name at read time — null if the auth provider
+  // never gave one, or the users row was since deleted.
+  changed_by_name: string | null;
   changed_at: string;
 };
 
@@ -199,6 +215,11 @@ export type DeveloperClaim = {
 export type PendingDeveloperClaim = DeveloperClaim & {
   developer_name: string;
   developer_type: (typeof DEVELOPER_TYPES)[number];
+  // The claimant's own account name/GitHub handle, so the moderator sees
+  // who's asking instead of just their opaque id. Null if the auth
+  // provider never gave a name, or the claimant hasn't linked GitHub yet.
+  claimant_name: string | null;
+  claimant_github_login: string | null;
 };
 
 // Result of POST /developers/{id}/transfer — the raw token is only ever

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -146,7 +146,8 @@ export type DeveloperProfile = Developer & {
 };
 
 // Body for PUT /extensions/v2/developers/me — everything but the server-set
-// `approved` flag, `content_revision`, and GitHub verification fields.
+// `approved` flag, `content_revision`, GitHub verification fields, and
+// owner-identity fields (only ever populated by the moderator list query).
 export type DeveloperProfileInput = Omit<
   DeveloperProfile,
   | 'approved'
@@ -155,6 +156,8 @@ export type DeveloperProfileInput = Omit<
   | 'github_org_verified'
   | 'github_verification_note'
   | 'github_verified_at'
+  | 'owner_name'
+  | 'owner_github_login'
 >;
 
 // What getDeveloperById (the public /developer/[id] read) returns —


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show human-friendly developer and claimant names in moderator views, and add GitHub verification with manual and login-triggered re-checks for profile owners. Extracts a shared `GithubVerifiedBadge` and throttles login re-verification to avoid extra API calls.

- **New Features**
  - Owner page shows a GitHub verified/not-verified badge with a last-checked tooltip and a "Re-verify" button, plus a result alert after re-checks.
  - Automatic re-verification runs on login (throttled to once per hour); added `reverifyDeveloper` to the API client.
  - Moderator views show owner/claimant names and GitHub handles; lists include owner info, an Unclaimed badge, and verification badges with timestamps.

- **Bug Fixes**
  - Linked-GitHub detection now checks `github_orgs` instead of `github_login`, ensuring users without org access still see the reconnect prompt.
  - Tightened types: excluded `github_verified_at`, `owner_name`, and `owner_github_login` from `DeveloperProfileInput`; and excluded `github_verified_at`, `owner_name`, and `owner_github_login` from `PublicDeveloperProfile`.

<sup>Written for commit f7c80f77a7cd450e22b127adb2742a39c505649e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

