### PR TITLE
Request GitHub claim scope from central auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ submitter/moderator status, and any other authorization concept live entirely in
 app's own `users` table (`src/lib/db/migrations/`), keyed by the auth service's `sub`
 claim, in the same `DB_EXTENSIONS` D1 database this app already reads from.
 
+The client requests the dedicated `github` scope when it needs the linked GitHub
+username and organization claims. The issuer omits those claims for tokens without
+that scope, and users may need to reauthorize after a scope change.
+
 Sessions are a self-contained, HMAC-signed cookie minted after the initial token
 exchange — this app does not depend on the auth service's own token lifetimes beyond
 that exchange.

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -8,7 +8,7 @@ const AUTHORIZE_ENDPOINT = `${ISSUER}/oauth2/authorize`;
 const TOKEN_ENDPOINT = `${ISSUER}/oauth2/token`;
 const USERINFO_ENDPOINT = `${ISSUER}/oauth2/userinfo`;
 
-const SCOPE = 'openid profile email';
+const SCOPE = 'openid profile email github';
 
 // Short-lived cookies that carry the PKCE verifier and CSRF state across the
 // redirect to the auth service and back. Cleared as soon as the callback
@@ -92,7 +92,8 @@ export type UserInfo = {
   picture?: string;
   // Linked GitHub identity, present once a user has signed in via GitHub
   // after the auth service started requesting the read:org scope — see
-  // upsertUser in users.ts. github_orgs is the caller's active org logins,
+  // upsertUser in users.ts. The github OIDC scope is required for these
+  // linked-identity claims. github_orgs is the caller's active org logins,
   // used to verify developer profile claims (api repo's claim()). The expiry
   // is an absolute RFC3339 timestamp from the central auth service; consumers
   // must treat a missing, malformed, or past value as no organization evidence.


### PR DESCRIPTION
## What changed

- Request the dedicated `github` OIDC scope alongside the existing OIDC scopes.
- Document that linked GitHub claims require this scope and may require reauthorization.

## Why

The central auth issuer now gates linked GitHub identity and organization claims behind the `github` scope. The extensions client must request that scope to preserve its existing GitHub-linked identity and organization verification behavior.