### PR TITLE
Handle actionable API errors during profile saves

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -25,6 +25,23 @@ export class ApiRequestError extends Error {
   }
 }
 
+/**
+ * Converts API failures that need special user guidance into actionable copy.
+ * Other failures retain the message supplied by the API.
+ */
+export function getApiErrorMessage(error: ApiRequestError): string {
+  switch (error.code) {
+    case 'RATE_LIMITED':
+      return 'Too many requests were made. Please wait a few minutes and try again.';
+    case 'SERVICE_UNAVAILABLE':
+      return 'The service is temporarily unavailable. Please try again manually in a few minutes.';
+    case 'GITHUB_ENTITY_UNSUPPORTED':
+      return error.message;
+    default:
+      return error.message;
+  }
+}
+
 export function createApiClient(env: Cloudflare.Env, sub: string) {
   async function call<T>(path: string, init?: RequestInit): Promise<T> {
     const token = await mintBearerAssertion(sub, env.ASSERTION_SIGNING_SECRET);

--- a/src/pages/account/developer/index.astro
+++ b/src/pages/account/developer/index.astro
@@ -2,7 +2,11 @@
 import Base from '../../../layouts/Base.astro';
 import { env } from 'cloudflare:workers';
 import { requireUser } from '@/lib/auth-guard';
-import { createApiClient, ApiRequestError } from '@/lib/apiClient';
+import {
+  createApiClient,
+  ApiRequestError,
+  getApiErrorMessage,
+} from '@/lib/apiClient';
 import {
   getDeveloperByOwner,
   getDeveloperById,
@@ -135,9 +139,11 @@ if (Astro.request.method === 'POST') {
       return Astro.redirect('/account');
     } catch (e) {
       error =
-        e instanceof ApiRequestError || e instanceof DeveloperValidationError
-          ? e.message
-          : 'Something went wrong saving your developer profile. Please try again.';
+        e instanceof ApiRequestError
+          ? getApiErrorMessage(e)
+          : e instanceof DeveloperValidationError
+            ? e.message
+            : 'Something went wrong saving your developer profile. Please try again.';
       // Matched on the api repo's dedicated DEVELOPER_ID_TAKEN code, not the
       // message text, so a reworded message can't silently break this. Only
       // points at the claim flow when the conflicting profile is actually


### PR DESCRIPTION
### Description
- Add a shared `getApiErrorMessage` helper in `src/lib/apiClient.ts` that branches on `ApiRequestError.code` for `RATE_LIMITED`, `SERVICE_UNAVAILABLE`, and `GITHUB_ENTITY_UNSUPPORTED`, returning retry-later wording for rate limits, temporary/manual-retry wording for service outages, and the server-provided message for unsupported GitHub entities, with a fallback to the API message for all other codes.
- Use `getApiErrorMessage` in the profile-save catch block in `src/pages/account/developer/index.astro` so API errors produce the new actionable copy while preserving `DeveloperValidationError` messages and the code-based `DEVELOPER_ID_TAKEN` claim flow.
- Keep assigning `submitted` before the API call and only update `developer`, set the success flash, and redirect after a resolved API call.