### PR TITLE
Improve GitHub re-verify flow with cooldown, clearer errors, and UI feedback

### DIFF
--- a/src/pages/account/developer/reverify.ts
+++ b/src/pages/account/developer/reverify.ts
@@ -10,6 +10,19 @@ export const POST: APIRoute = async (context) => {
   if (guard instanceof Response) return guard;
   const user = guard;
 
+  const cooldownUntil =
+    (await context.session?.get('reverifyCooldownUntil')) ?? 0;
+  if (cooldownUntil > Date.now()) {
+    setFlash(context.session, {
+      category: 'error',
+      title: 'Could not refresh GitHub verification',
+      description:
+        'GitHub verification is temporarily unavailable. Please wait until the one-minute cooldown ends, then retry manually.',
+    });
+    return context.redirect('/account');
+  }
+  context.session?.delete('reverifyCooldownUntil');
+
   const developer = await getDeveloperByOwner(env.DB_EXTENSIONS, user.sub);
   if (!developer) return context.redirect('/account');
 

--- a/src/pages/account/developer/reverify.ts
+++ b/src/pages/account/developer/reverify.ts
@@ -18,11 +18,35 @@ export const POST: APIRoute = async (context) => {
   try {
     result = await api.reverifyDeveloper(true);
   } catch (e) {
-    const message =
-      e instanceof ApiRequestError
-        ? e.message
-        : 'Unable to re-verify your GitHub identity right now. Please try again.';
-    setFlash(context.session, { category: 'error', title: message });
+    let description =
+      'Unable to refresh your GitHub verification right now. Please try again manually.';
+
+    if (e instanceof ApiRequestError) {
+      switch (e.code) {
+        case 'RATE_LIMITED':
+          description =
+            'GitHub verification is temporarily rate limited. Please wait one minute, then retry manually.';
+          context.session?.set('reverifyCooldownUntil', Date.now() + 60_000);
+          break;
+        case 'SERVICE_UNAVAILABLE':
+          description =
+            'GitHub verification is temporarily unavailable. Please wait one minute, then retry manually.';
+          context.session?.set('reverifyCooldownUntil', Date.now() + 60_000);
+          break;
+        case 'GITHUB_ENTITY_UNSUPPORTED':
+          description =
+            'This type of GitHub entity is not supported. Change the linked GitHub account or Publisher ID before re-verifying; retrying unchanged will not help.';
+          break;
+        default:
+          description = e.message;
+      }
+    }
+
+    setFlash(context.session, {
+      category: 'error',
+      title: 'Could not refresh GitHub verification',
+      description,
+    });
     return context.redirect('/account');
   }
 

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -53,6 +53,13 @@ const pendingClaim = myClaims.find((c) => c.status === 'pending');
 // since, leaving the page with no way to proceed.
 const displayClaim = pendingClaim ?? latestClaim;
 
+let reverifyCooldownUntil =
+  (await Astro.session?.get('reverifyCooldownUntil')) ?? 0;
+if (reverifyCooldownUntil <= Date.now()) {
+  Astro.session?.delete('reverifyCooldownUntil');
+  reverifyCooldownUntil = 0;
+}
+
 const statusBadgeVariant: Record<Submission['status'], string | undefined> = {
   pending: 'secondary',
   approved: undefined,
@@ -182,10 +189,21 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
                   >
                     View Public Profile
                   </a>
-                  <form method="POST" action="/account/developer/reverify">
+                  <form
+                    method="POST"
+                    action="/account/developer/reverify"
+                    data-reverify-form
+                    data-cooldown-until={reverifyCooldownUntil || undefined}
+                  >
                     <button
                       type="submit"
                       class="btn"
+                      disabled={reverifyCooldownUntil > 0}
+                      aria-label={
+                        reverifyCooldownUntil > 0
+                          ? 'Re-verify unavailable temporarily'
+                          : 'Re-verify'
+                      }
                       data-size="sm"
                       data-variant={
                         developer.github_org_verified === false
@@ -195,7 +213,9 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
                       data-tooltip="Check GitHub verification now"
                       data-side="bottom"
                     >
-                      Re-verify
+                      {reverifyCooldownUntil > 0
+                        ? 'Try again shortly'
+                        : 'Re-verify'}
                     </button>
                   </form>
                 </div>
@@ -364,3 +384,36 @@ const reconnectUrl = `${ISSUER}/account?callbackURL=${encodeURIComponent(
     </div>
   </div>
 </Base>
+
+<script>
+  const form = document.querySelector<HTMLFormElement>('[data-reverify-form]');
+  const button = form?.querySelector<HTMLButtonElement>(
+    'button[type="submit"]',
+  );
+
+  if (form && button) {
+    const cooldownUntil = Number(form.dataset.cooldownUntil ?? 0);
+    if (cooldownUntil > Date.now()) {
+      button.disabled = true;
+      window.setTimeout(() => {
+        button.disabled = false;
+        button.textContent = 'Re-verify';
+        button.setAttribute('aria-label', 'Re-verify');
+      }, cooldownUntil - Date.now());
+    }
+
+    let submitting = false;
+    form.addEventListener('submit', (event) => {
+      if (submitting || cooldownUntil > Date.now()) {
+        event.preventDefault();
+        return;
+      }
+
+      submitting = true;
+      button.disabled = true;
+      button.textContent = 'Re-verifying…';
+      button.setAttribute('aria-label', 'Re-verifying GitHub account');
+      button.setAttribute('aria-busy', 'true');
+    });
+  }
+</script>


### PR DESCRIPTION
### Description

- Enhanced server-side error handling in `POST /account/developer/reverify` to inspect `ApiRequestError` `code` values and map them to specific user-facing descriptions, including handling `RATE_LIMITED`, `SERVICE_UNAVAILABLE`, and `GITHUB_ENTITY_UNSUPPORTED` cases.
- Store a short cooldown timestamp in the session under `reverifyCooldownUntil` when rate-limited or service-unavailable responses are returned so the UI can temporarily disable reverify attempts.
- Updated account page (`src/pages/account/index.astro`) to read and clear `reverifyCooldownUntil` from the session and pass it to the reverify form as `data-cooldown-until` and `data-reverify-form`.
- Disabled the reverify button when a cooldown is active and update its label to `Try again shortly` while disabled, plus added a client-side script to manage button state, show a `Re-verifying…` label and `aria-busy` while submitting, and re-enable the button when the cooldown expires.
- Adjusted flash messages to include a consistent title (`Could not refresh GitHub verification`) and a more specific `description` field when errors occur.