### PR TITLE
Allow trusted dependency install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
   },
   "overrides": {
     "vite": "^8.0.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true,
+    "workerd@1.20260730.1": true
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Whitelists postinstall scripts for `esbuild@0.28.1`, `fsevents@2.3.3`, and `workerd@1.20260730.1` via `allowScripts` in package.json. This unblocks CI and local installs where scripts are restricted, with no runtime changes.

<sup>Written for commit c2e5fb97cf7f0d2e7e98dd803850fa43c2ca5e87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

