### PR TITLE
Fix developer trust badge tooltip clipping off-screen

### DIFF
--- a/src/components/ProfileTrustBadge.astro
+++ b/src/components/ProfileTrustBadge.astro
@@ -69,7 +69,7 @@ const tooltip =
       class="inline-flex font-normal"
       data-tooltip={tooltip}
       data-side="bottom"
-      data-align="end"
+      data-align="start"
       role="img"
       aria-label={tooltip}
     >


### PR DESCRIPTION
## Summary
- `ProfileTrustBadge`'s tooltip was hardcoded to `data-align="end"`, which anchors the tooltip's right edge to the badge and makes it grow **leftward**.
- That alignment makes sense for the top-right nav icons in `Base.astro` (anchored at the page's right edge), but this badge sits inline right after a developer's name — so `end` made the tooltip grow backward over the name instead of into the open space that follows it.
- For the longer tooltip text (e.g. "GitHub identity verified (last checked ...)"), this pushed the bubble off the left edge of the viewport and clipped it.
- Changed to `data-align="start"` so the tooltip opens rightward into free space.