### PR TITLE
Refine v2 schemas and improve generated types

### DIFF
--- a/openapi/extensions-v2.json
+++ b/openapi/extensions-v2.json
@@ -28,16 +28,7 @@
             }
           },
           "pagination": {
-            "type": "object",
-            "properties": {
-              "next_cursor": {
-                "type": ["string", "null"]
-              },
-              "has_more": {
-                "type": "boolean"
-              }
-            },
-            "required": ["next_cursor", "has_more"]
+            "$ref": "#/components/schemas/Pagination"
           }
         },
         "required": ["result", "pagination"]
@@ -182,6 +173,18 @@
           }
         },
         "required": ["id", "type", "name", "approved", "unclaimed"]
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "next_cursor": {
+            "type": ["string", "null"]
+          },
+          "has_more": {
+            "type": "boolean"
+          }
+        },
+        "required": ["next_cursor", "has_more"]
       },
       "Error": {
         "type": "object",
@@ -509,18 +512,6 @@
           "reviewed_at"
         ]
       },
-      "Pagination": {
-        "type": "object",
-        "properties": {
-          "next_cursor": {
-            "type": ["string", "null"]
-          },
-          "has_more": {
-            "type": "boolean"
-          }
-        },
-        "required": ["next_cursor", "has_more"]
-      },
       "DeveloperClaim": {
         "type": "object",
         "properties": {
@@ -574,7 +565,8 @@
             "type": "string",
             "maxLength": 500
           }
-        }
+        },
+        "additionalProperties": false
       },
       "PendingDeveloperClaim": {
         "allOf": [
@@ -691,7 +683,8 @@
             "maxLength": 2000
           }
         },
-        "required": ["review_note"]
+        "required": ["review_note"],
+        "additionalProperties": false
       },
       "DeveloperTransfer": {
         "type": "object",
@@ -724,7 +717,8 @@
             "type": "string",
             "maxLength": 2000
           }
-        }
+        },
+        "additionalProperties": false
       },
       "DeveloperApproval": {
         "type": "object",
@@ -796,6 +790,41 @@
             "type": "null"
           }
         ]
+      },
+      "DeveloperInput": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["user", "organization"]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "URL": {
+            "type": "string",
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "avatar_url": {
+            "type": "string",
+            "maxLength": 2048,
+            "format": "uri"
+          },
+          "contact_email": {
+            "type": "string",
+            "maxLength": 254,
+            "format": "email"
+          }
+        },
+        "required": ["id", "type", "name"],
+        "additionalProperties": false
       }
     },
     "parameters": {}
@@ -1474,6 +1503,7 @@
           {
             "schema": {
               "type": "string",
+              "minLength": 1,
               "maxLength": 1000
             },
             "required": false,
@@ -2420,6 +2450,7 @@
           {
             "schema": {
               "type": "string",
+              "minLength": 1,
               "maxLength": 1000
             },
             "required": false,
@@ -3127,7 +3158,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Developer"
+                "$ref": "#/components/schemas/DeveloperInput"
               }
             }
           }

--- a/scripts/update-extensions-openapi.mjs
+++ b/scripts/update-extensions-openapi.mjs
@@ -13,9 +13,20 @@ if (!response.ok) {
 
 const document = await response.json();
 const schemas = document?.components?.schemas;
+
+const resolveSchema = (schema) => {
+  const ref = schema?.$ref;
+  if (typeof ref !== 'string') return schema;
+  const prefix = '#/components/schemas/';
+  if (!ref.startsWith(prefix)) return schema;
+  return schemas?.[ref.slice(prefix.length)];
+};
+
+const paginationSchema = resolveSchema(
+  schemas?.ExtensionListResponse?.properties?.pagination,
+);
 const cursorSchemas = [
-  schemas?.ExtensionListResponse?.properties?.pagination?.properties
-    ?.next_cursor,
+  paginationSchema?.properties?.next_cursor,
   schemas?.Pagination?.properties?.next_cursor,
 ];
 

--- a/src/lib/api/generated/extensions-v2/index.ts
+++ b/src/lib/api/generated/extensions-v2/index.ts
@@ -50,6 +50,7 @@ export type {
   DeveloperApproval,
   DeveloperClaim,
   DeveloperHistoryEntry,
+  DeveloperInput,
   DeveloperProfile,
   DeveloperTransfer,
   Error,

--- a/src/lib/api/generated/extensions-v2/types.gen.ts
+++ b/src/lib/api/generated/extensions-v2/types.gen.ts
@@ -6,10 +6,7 @@ export type ClientOptions = {
 
 export type ExtensionListResponse = {
   result: Array<ExtensionListItem>;
-  pagination: {
-    next_cursor: string | null;
-    has_more: boolean;
-  };
+  pagination: Pagination;
 };
 
 export type ExtensionListItem = {
@@ -51,6 +48,11 @@ export type PublicDeveloper = {
   avatar_url?: string;
   approved: boolean;
   unclaimed: boolean;
+};
+
+export type Pagination = {
+  next_cursor: string | null;
+  has_more: boolean;
 };
 
 export type Error = {
@@ -150,11 +152,6 @@ export type Submission = {
   reviewed_at: string | null;
 };
 
-export type Pagination = {
-  next_cursor: string | null;
-  has_more: boolean;
-};
-
 export type DeveloperClaim = {
   id: string;
   developer_id: string;
@@ -237,6 +234,15 @@ export type OwnedDeveloperProfile =
       has_pending_transfer: boolean;
     })
   | null;
+
+export type DeveloperInput = {
+  id: string;
+  type: 'user' | 'organization';
+  name: string;
+  URL?: string;
+  avatar_url?: string;
+  contact_email?: string;
+};
 
 export type GetExtensionsMineData = {
   body?: never;
@@ -1465,7 +1471,7 @@ export type GetDevelopersMeResponse =
   GetDevelopersMeResponses[keyof GetDevelopersMeResponses];
 
 export type PutDevelopersMeData = {
-  body?: Developer;
+  body?: DeveloperInput;
   path?: never;
   query?: never;
   url: '/developers/me';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refined extensions v2 OpenAPI schemas and regenerated types to use a shared `Pagination`, add `DeveloperInput`, and tighten input validation. Updated the update script to resolve `$ref` for pagination so `next_cursor` typing stays correct.

- **Refactors**
  - Replaced inline pagination with `components/schemas/Pagination` and removed duplicates.
  - Introduced `DeveloperInput` and switched PUT `/developers/me` to use it; exported in generated types.
  - Added `additionalProperties: false` and `minLength: 1` to relevant inputs to reject unknown fields and empty strings.
  - Updated `scripts/update-extensions-openapi.mjs` to resolve `$ref` before reading `next_cursor`.

<sup>Written for commit e81cb93d7567cfb8f7dc3e6f206572bbe00cd3a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

